### PR TITLE
refactor(core): Improve package caching and symlink path expansion

### DIFF
--- a/.meowg1k/config.yaml
+++ b/.meowg1k/config.yaml
@@ -11,6 +11,8 @@ generate:
 
   tasks:
     review:
+      provider: "gemini"
+      model: "gemini-2.5-pro"
       userPrompt: >-
         Perform a thorough code review of the following shell script.
 
@@ -31,6 +33,8 @@ generate:
           3) Quick wins — checklist of small fixes.
 
     commit:
+      provider: "gemini"
+      model: "gemini-2.5-pro"
       userPrompt: >-
         Generate a Conventional Commit message for the provided changes to shell
         scripts or dotfiles.
@@ -93,6 +97,8 @@ generate:
             often using 'uname' to detect the OS.
 
     pr:
+      provider: "gemini"
+      model: "gemini-2.5-pro"
       userPrompt: >-
         Create a clear and actionable Pull Request description from the provided
         diff for a dotfiles project. Produce Markdown in a standard PR template

--- a/lib/package/cargo.sh
+++ b/lib/package/cargo.sh
@@ -9,7 +9,15 @@ source "${MEOW}/lib/package/common.sh"
 source "${MEOW}/lib/core/dry_run.sh"
 
 _cache_installed_cargo_packages() {
-  cache_package_list "cargo" "cargo install --list 2>/dev/null | awk '/:/ {print \$1}'"
+  local cache_var="_CARGO_INSTALLED_PACKAGES"
+
+  if [ -z "${!cache_var:-}" ]; then
+    ui_verbose_action_start "Caching installed cargo packages..."
+    local output
+    output=$(cargo install --list 2>/dev/null | awk '/:/ {print $1}' || true)
+    eval "$cache_var=\"\$output\""
+    ui_verbose_action_success "Successfully cached cargo packages."
+  fi
 }
 
 is_cargo_package_installed() {

--- a/lib/package/homebrew.sh
+++ b/lib/package/homebrew.sh
@@ -11,7 +11,17 @@ source "${MEOW}/lib/package/common.sh"
 source "${MEOW}/lib/core/dry_run.sh"
 
 _cache_installed_brew_packages() {
-  cache_package_list "brew" "brew list --formula -1 2>/dev/null; brew list --cask -1 2>/dev/null"
+  local formula_list cask_list combined_list
+  formula_list=$(brew list --formula -1 2>/dev/null || true)
+  cask_list=$(brew list --cask -1 2>/dev/null || true)
+  combined_list="${formula_list}${formula_list:+$'\n'}${cask_list}"
+  
+  local cache_var="_BREW_INSTALLED_PACKAGES"
+  if [ -z "${!cache_var:-}" ]; then
+    ui_verbose_action_start "Caching installed brew packages..."
+    eval "$cache_var=\"\$combined_list\""
+    ui_verbose_action_success "Successfully cached brew packages."
+  fi
 }
 
 is_homebrew_package_installed() {

--- a/lib/package/mas.sh
+++ b/lib/package/mas.sh
@@ -11,7 +11,15 @@ source "${MEOW}/lib/package/common.sh"
 source "${MEOW}/lib/core/dry_run.sh"
 
 _cache_installed_mas_packages() {
-  cache_package_list "mas" "mas list | awk '{print \$1}'"
+  local cache_var="_MAS_INSTALLED_PACKAGES"
+
+  if [ -z "${!cache_var:-}" ]; then
+    ui_verbose_action_start "Caching installed mas packages..."
+    local output
+    output=$(mas list | awk '{print $1}' 2>/dev/null || true)
+    eval "$cache_var=\"\$output\""
+    ui_verbose_action_success "Successfully cached mas packages."
+  fi
 }
 
 is_mas_package_installed() {

--- a/lib/package/npm.sh
+++ b/lib/package/npm.sh
@@ -9,11 +9,15 @@ source "${MEOW}/lib/package/common.sh"
 source "${MEOW}/lib/core/dry_run.sh"
 
 _cache_installed_npm_packages() {
-  local npm_list_cmd
-  npm_list_cmd="npm list -g --depth=0 --parseable 2>/dev/null"
-  npm_list_cmd="$npm_list_cmd | grep 'node_modules/'"
-  npm_list_cmd="$npm_list_cmd | sed 's|.*/node_modules/||'"
-  cache_package_list "npm" "$npm_list_cmd"
+  local cache_var="_NPM_INSTALLED_PACKAGES"
+  
+  if [ -z "${!cache_var:-}" ]; then
+    ui_verbose_action_start "Caching installed npm packages..."
+    local output
+    output=$(npm list -g --depth=0 --parseable 2>/dev/null | grep 'node_modules/' | sed 's|.*/node_modules/||' || true)
+    eval "$cache_var=\"\$output\""
+    ui_verbose_action_success "Successfully cached npm packages."
+  fi
 }
 
 is_npm_package_installed() {

--- a/lib/package/pipx.sh
+++ b/lib/package/pipx.sh
@@ -9,7 +9,15 @@ source "${MEOW}/lib/package/common.sh"
 source "${MEOW}/lib/core/dry_run.sh"
 
 _cache_installed_pipx_packages() {
-  cache_package_list "pipx" "pipx list --short 2>/dev/null | awk '{print \$1}'"
+  local cache_var="_PIPX_INSTALLED_PACKAGES"
+
+  if [ -z "${!cache_var:-}" ]; then
+    ui_verbose_action_start "Caching installed pipx packages..."
+    local output
+    output=$(pipx list --short 2>/dev/null | awk '{print $1}' || true)
+    eval "$cache_var=\"\$output\""
+    ui_verbose_action_success "Successfully cached pipx packages."
+  fi
 }
 
 is_pipx_package_installed() {

--- a/lib/symlinks/symlinks.sh
+++ b/lib/symlinks/symlinks.sh
@@ -15,7 +15,8 @@ _LIB_PACKAGE_SYMLINKS_SOURCED=1
 
 expand_path() {
   local path="$1"
-  echo "$path"
+  # Expand environment variables and tilde
+  eval echo "$path"
 }
 
 create_symlink() {


### PR DESCRIPTION
This commit refactors the package caching mechanism for better robustness and user feedback.  It also fixes an issue with path expansion for symlinks.

The `_cache_installed_*_packages` functions for Homebrew, Cargo, npm, etc., are updated to inline the caching logic instead of using a generic helper.  This change introduces verbose output to inform the user when caching occurs and makes the scripts more resilient by handling potential failures from package manager commands gracefully using `|| true`.

Additionally, the `expand_path` function is fixed to correctly expand tilde (`~`) and environment variables in symlink source and target paths by using `eval echo`.

Finally, the internal `meowg1k` configuration is updated to use the `gemini-2.5-pro` model for its tasks.