### PR TITLE
fix(package): add command availability guards and fix mise UI calls

### DIFF
--- a/components/development-essential/component.yaml
+++ b/components/development-essential/component.yaml
@@ -9,3 +9,4 @@ depends_on:
 - go-task
 - node-development
 - neovim
+- tool-installers

--- a/lib/package/cargo.sh
+++ b/lib/package/cargo.sh
@@ -87,6 +87,11 @@ install_cargo_packages() {
       export PATH="$mise_shims_dir:$PATH"
     fi
   fi
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    ui_action_error "cargo not found. Please install Rust/Cargo first."
+    return 1
+  fi
   
   local component="$1"
   local manager_name="cargo"

--- a/lib/package/gem.sh
+++ b/lib/package/gem.sh
@@ -87,6 +87,11 @@ install_gem_packages() {
       export PATH="$mise_shims_dir:$PATH"
     fi
   fi
+
+  if ! command -v gem >/dev/null 2>&1; then
+    ui_action_error "gem not found. Please install Ruby first."
+    return 1
+  fi
   
   install_packages_generic "$1" "gem" "gem install" "is_gem_package_installed"
 }

--- a/lib/package/go.sh
+++ b/lib/package/go.sh
@@ -100,6 +100,11 @@ install_go_packages() {
       export PATH="$mise_shims_dir:$PATH"
     fi
   fi
+
+  if ! command -v go >/dev/null 2>&1; then
+    ui_action_error "go not found. Please install Go first."
+    return 1
+  fi
   
   install_packages_generic "$1" "go" "go install" "is_go_package_installed"
 }

--- a/lib/package/mise.sh
+++ b/lib/package/mise.sh
@@ -93,14 +93,18 @@ setup_mise() {
 #   go
 install_mise_packages() {
   local component="$1"
-  local manager_name="mise"
   local list_file="${MEOW}/components/${component}/packages/mise.list"
 
   if [ ! -f "$list_file" ]; then
     return 0
   fi
 
-  ui_step_header "$(printf "Installing %s packages for '%s'" "$(ui_format_package_manager_name "$manager_name")" "$component")"
+  if ! command -v mise >/dev/null 2>&1; then
+    ui_action_error "mise not found. Please install mise first."
+    return 1
+  fi
+
+  ui_step_header "$(printf "Installing mise packages for '%s'" "$component")"
 
   if is_dry_run; then
     dry_run_ui_info "Would install mise packages from: $list_file"
@@ -137,7 +141,7 @@ install_mise_packages() {
   done < "$list_file"
 
   # Summary
-  ui_action_info "$(printf "mise: %d installed, %d already present" "$installed_count" "$already_present_count")"
+  ui_indent "$(printf "mise: %d installed, %d already present" "$installed_count" "$already_present_count")"
   
   if [ $failed_count -gt 0 ]; then
     ui_action_warning "$(printf "mise: %d failed" "$failed_count")"
@@ -190,7 +194,6 @@ mise_use_global_from_list() {
 # Update mise tools for a component
 update_mise_packages() {
   local component="$1"
-  local manager_name="mise"
   local list_file="${MEOW}/components/${component}/packages/mise.list"
 
   if [ ! -f "$list_file" ]; then
@@ -254,14 +257,13 @@ update_mise_packages() {
 # Uninstall mise tools for a component
 uninstall_mise_packages() {
   local component="$1"
-  local manager_name="mise"
   local list_file="${MEOW}/components/${component}/packages/mise.list"
 
   if [ ! -f "$list_file" ]; then
     return 0
   fi
 
-  ui_step_header "$(printf "Uninstalling %s packages for '%s'" "$(ui_format_package_manager_name "$manager_name")" "$component")"
+  ui_step_header "$(printf "Uninstalling mise packages for '%s'" "$component")"
 
   if is_dry_run; then
     dry_run_ui_info "Would uninstall mise packages from: $list_file"
@@ -301,10 +303,10 @@ uninstall_mise_packages() {
   done < "$list_file"
 
   # Summary
-  ui_action_info "$(printf "mise: %d uninstalled" "$uninstalled_count")"
+  ui_indent "$(printf "mise: %d uninstalled" "$uninstalled_count")"
   
   if [ $not_installed_count -gt 0 ]; then
-    ui_action_info "$(printf "mise: %d not installed" "$not_installed_count")"
+    ui_indent "$(printf "mise: %d not installed" "$not_installed_count")"
   fi
   
   if [ $failed_count -gt 0 ]; then

--- a/lib/package/npm.sh
+++ b/lib/package/npm.sh
@@ -87,6 +87,11 @@ install_npm_packages() {
       export PATH="$mise_shims_dir:$PATH"
     fi
   fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    ui_action_error "npm not found. Please install Node.js/npm first."
+    return 1
+  fi
   
   install_packages_generic "$1" "npm" "npm install -g" "is_npm_package_installed"
 }

--- a/lib/package/pipx.sh
+++ b/lib/package/pipx.sh
@@ -87,6 +87,11 @@ install_pipx_packages() {
       export PATH="$mise_shims_dir:$PATH"
     fi
   fi
+
+  if ! command -v pipx >/dev/null 2>&1; then
+    ui_action_error "pipx not found. Please install pipx first (e.g., 'brew install pipx')."
+    return 1
+  fi
   
   install_packages_generic "$1" "pipx" "pipx install" "is_pipx_package_installed"
 }


### PR DESCRIPTION
## Summary

- Add early-exit guard clauses to all package installer functions (`cargo`, `gem`, `go`, `npm`, `pipx`) that fail gracefully with a clear error message when the required tool is not found after attempting mise shim PATH resolution
- Fix `mise.sh` to use `ui_indent` instead of non-existent `ui_action_info` function, remove unused `manager_name` variables, and inline package manager name in UI header messages
- Add `tool-installers` as a dependency of `development-essential` component to ensure package managers are available before package installation

## Changes

### Package manager guard clauses
Each `install_*_packages` function already attempts to add mise shims to `PATH` when the tool isn't found. However, if the tool is *still* not available after that, the functions would proceed and fail with cryptic errors. Now they emit a clear error via `ui_action_error` and return early with exit code 1.

Affected files: `cargo.sh`, `gem.sh`, `go.sh`, `npm.sh`, `pipx.sh`

### Mise UI fixes
- `ui_action_info` does not exist in the codebase — replaced with `ui_indent` (defined in `lib/core/ui.sh`)
- Removed `manager_name` local variables that were only used for the previously-removed `ui_format_package_manager_name` calls
- Inlined "mise" directly in UI messages

### Dependency ordering
Added `tool-installers` to `development-essential/component.yaml` `depends_on` list so that language runtimes (and their package managers) are installed before development tool packages that depend on them.