### PR TITLE
chore(brew): sync installed packages with components

### DIFF
--- a/components/ai-tools/packages/homebrew.list
+++ b/components/ai-tools/packages/homebrew.list
@@ -1,2 +1,1 @@
-llama.cpp
 copilot-cli

--- a/components/desktop-utilities/packages/homebrew.list
+++ b/components/desktop-utilities/packages/homebrew.list
@@ -3,3 +3,5 @@ maccy
 appcleaner
 shottr
 hiddenbar
+displayplacer
+mole

--- a/components/neovide/component.yaml
+++ b/components/neovide/component.yaml
@@ -1,0 +1,7 @@
+description: Neovide GUI client for Neovim. Provides a native desktop application
+  with GPU-accelerated rendering for Neovim.
+platforms:
+- match:
+    platform: macos
+depends_on:
+- neovim

--- a/components/neovide/packages/homebrew.list
+++ b/components/neovide/packages/homebrew.list
@@ -1,0 +1,1 @@
+neovide


### PR DESCRIPTION
## Summary

- Remove `llama.cpp` from `ai-tools` homebrew.list (not installed)
- Add `displayplacer` and `mole` to `desktop-utilities` homebrew.list
- Add new `neovide` component (macOS only, depends on `neovim`)
- `gemini-cli` is now managed via npm (`@google/gemini-cli` in `ai-tools/npm.list`); brew formula removed
- `pyenv` uninstalled — superseded by `mise` for Python version management
- `librsvg` uninstalled — orphaned with no dependents