### PR TITLE
fix(mise): clean up config generator and sync global tools on uninstall

### DIFF
--- a/components/tool-installers/scripts/setup.sh
+++ b/components/tool-installers/scripts/setup.sh
@@ -43,7 +43,9 @@ setup_mise() {
     ui_info "Created mise config directory: $mise_config_dir"
   fi
   
-  # Create global mise.toml if it doesn't exist
+  # Create global config.toml with [settings] if it doesn't exist.
+  # The [tools] section is managed by mise_use_global_from_list, which is
+  # called automatically after each component's mise.list is installed.
   local mise_config="$mise_config_dir/config.toml"
   if [ ! -f "$mise_config" ]; then
     cat > "$mise_config" << 'EOF'
@@ -53,16 +55,6 @@ setup_mise() {
 [settings]
 # Automatically install missing tools
 auto_install = true
-
-# Use verbose output for debugging
-# verbose = true
-
-# Global tools
-# Uncomment and add versions as needed
-# [tools]
-# python = "3.12"
-# node = "20"
-# go = "1.22"
 EOF
     ui_info "Created mise config: $mise_config"
   else

--- a/lib/package/mise.sh
+++ b/lib/package/mise.sh
@@ -289,9 +289,10 @@ uninstall_mise_packages() {
       continue
     fi
 
-    # Uninstall all versions of the tool
+    # Uninstall all versions of the tool and remove from global config
     ui_action_start "Uninstalling $tool_name..."
     if mise uninstall "$tool_name" --all >/dev/null 2>&1; then
+      mise use -g --remove "$tool_name" >/dev/null 2>&1 || true
       ui_action_success "$(printf "%-40s %s" "$tool_name" "✓ uninstalled")"
       ((uninstalled_count++))
     else


### PR DESCRIPTION
## Summary
- \`setup.sh\` now writes only a minimal \`[settings]\` block on first run, removing stub \`[tools]\` comments that incorrectly implied the file was the source of truth for installed tools.
- \`uninstall_mise_packages\` now calls \`mise use -g --remove\` after uninstalling a tool, keeping \`config.toml\` in sync when components are removed.

## Motivation
The \`[tools]\` section of \`~/.config/mise/config.toml\` is generated dynamically by \`mise_use_global_from_list\` as components are installed. The old stub content in \`setup.sh\` was misleading noise, and uninstalling a component left its tools as stale entries in the global config indefinitely.

## Changes
- **\`components/tool-installers/scripts/setup.sh\`**: Removed dead commented-out \`[tools]\` block and \`# verbose\` stub from the generated config template.
- **\`lib/package/mise.sh\`**: Added \`mise use -g --remove "$tool_name"\` to \`uninstall_mise_packages\` so the global config stays consistent with what is actually installed.

## Technical Details
\`mise use --global --remove\` is the idiomatic way to drop a tool from the global config without affecting other entries. The \`|| true\` guard prevents a failed removal from blocking the rest of the uninstall flow.

## Breaking Changes
None.

## Testing
Verified manually: \`mise list\` and \`~/.config/mise/config.toml\` are consistent after the changes.