### PR TITLE
feat(image-tools): add image-tools component with imagemagick

### DIFF
--- a/components/image-tools/component.yaml
+++ b/components/image-tools/component.yaml
@@ -1,0 +1,8 @@
+description: Image processing tools for terminal image rendering and media manipulation
+platforms:
+- match:
+    platform: macos
+- match:
+    platform: linux
+depends_on:
+- shell-essential

--- a/components/image-tools/packages/homebrew.list
+++ b/components/image-tools/packages/homebrew.list
@@ -1,0 +1,1 @@
+imagemagick

--- a/components/meowvim/component.yaml
+++ b/components/meowvim/component.yaml
@@ -9,3 +9,4 @@ platforms:
     platform: linux
 depends_on:
 - neovim
+- image-tools


### PR DESCRIPTION
## Summary

- Add new `image-tools` component providing image processing tools for terminal image rendering and media manipulation
- Include `imagemagick` via Homebrew, supporting both macOS and Linux platforms
- Update `meowvim` to depend on `image-tools` to enable image support in Neovim