### PR TITLE
fix(packages): correct pandoc tool name and remove uninstalled vscode extension

### DIFF
--- a/components/markdown/packages/mise.list
+++ b/components/markdown/packages/mise.list
@@ -1,1 +1,1 @@
-pandoc
+ubi:jgm/pandoc@3.9.0.2

--- a/components/visual-studio-code/packages/vscode.list
+++ b/components/visual-studio-code/packages/vscode.list
@@ -3,7 +3,6 @@ github.vscode-pull-request-github
 enkia.tokyo-night
 robbowen.synthwave-vscode
 catppuccin.catppuccin-vsc
-dooez.alt-catppuccin-vsc
 ms-azuretools.vscode-containers
 ms-azuretools.vscode-docker
 mohsen1.prettify-json


### PR DESCRIPTION
## Summary

- Renames `pandoc` → `ubi:jgm/pandoc@3.9.0.2` in `markdown/mise.list` — pandoc is installed via the `ubi` backend, not the native mise registry, so the tool identifier must include the `ubi:jgm/` prefix
- Removes `dooez.alt-catppuccin-vsc` from `visual-studio-code/vscode.list` — the extension is not installed; `catppuccin.catppuccin-vsc` is the active theme

Also manually restored `~/.config/meow/config.yaml` as a symlink to `private/meow/config.yaml` (was overwritten as a plain file by the theme system).

Doctor passes clean after these fixes.