### PR TITLE
feat(components): add opencode configuration component

### DIFF
--- a/components/development-essential/packages/homebrew.list
+++ b/components/development-essential/packages/homebrew.list
@@ -1,0 +1,2 @@
+glab
+worktrunk

--- a/components/opencode/component.yaml
+++ b/components/opencode/component.yaml
@@ -1,0 +1,9 @@
+description: Global OpenCode configuration — skills, commands, MCP servers, and shell strategy for AI-assisted development
+platforms:
+- match:
+    platform: macos
+- match:
+    platform: linux
+depends_on:
+- ai-tools
+- development-essential

--- a/components/opencode/config/opencode/commands/brainstorm.md
+++ b/components/opencode/config/opencode/commands/brainstorm.md
@@ -1,0 +1,13 @@
+---
+description: Brainstorm solutions — explore a problem, generate options, write a spec
+---
+
+Run the brainstorm phase of the workflow. This is an interactive process.
+
+Arguments: `/brainstorm [project-slug] [problem-description]`
+
+1. Identify the project (`$1`) and problem (`$2`). Ask if not provided.
+2. Load `workflow` skill and `workflow/brainstorm` sub-skill. Load context files per the matrix.
+3. Follow the brainstorm workflow in full. Present the spec at the hard gate.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/commands/debug.md
+++ b/components/opencode/config/opencode/commands/debug.md
@@ -1,0 +1,13 @@
+---
+description: Debug a problem — gather evidence, form hypotheses, find root cause
+---
+
+Run the debug workflow. This is an interactive process.
+
+Arguments: `/debug [symptom] [context]`
+
+1. Gather the symptom (`$1`) and context (`$2`). Ask if not provided.
+2. Load `workflow` skill and `workflow/debug` sub-skill. Load context files per the matrix.
+3. Follow the debug workflow in full. Present root cause and proposed fix at the hard gate.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/commands/draft.md
+++ b/components/opencode/config/opencode/commands/draft.md
@@ -1,0 +1,23 @@
+---
+description: Draft a document — postmortem, proposal, RFC, or any other type
+---
+
+Draft a document. This is an interactive process.
+
+Arguments: `/draft <type> [title]`
+
+Types: `postmortem`, `proposal`, `rfc` (or any freeform type).
+
+1. Load `writing` skill.
+2. Parse type from `$1`. If missing, ask with options: postmortem, proposal, RFC, other.
+3. Identify the title (`$2`) and destination — where will this be published or shared? (e.g., "Engineering blog", "internal wiki", "team Slack"). Ask if not provided. Use the destination as `{{TARGET}}`.
+4. Gather details based on type:
+   - **postmortem** — date, summary, timeline, root cause, contributing factors, resolution, action items.
+   - **proposal** — goal, background, proposed approach, success criteria, risks.
+   - **rfc** — problem statement, proposed solution, alternatives considered, open questions.
+   - **other** — ask the user for the document structure and key sections.
+   Ask for missing values interactively.
+5. Write to `drafts/<type>-<kebab-title>.md` in the current directory. Use the template at `~/.config/opencode/templates/draft-template.md` — replace `{{TARGET}}`, `{{DATE}}`, `{{TITLE}}`, and `{{CONTENT}}` with real values.
+6. Load the `conventions` skill for the required commit message format. Commit.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/commands/implement.md
+++ b/components/opencode/config/opencode/commands/implement.md
@@ -1,0 +1,14 @@
+---
+description: Implement an approved plan — execute tasks, write code or documents
+---
+
+Run the implement phase of the workflow.
+
+Arguments: `/implement [plan-path-or-project-slug]`
+
+1. Identify the plan (`$1`). If a project slug is given, list plans in `projects/<slug>/plans/`. Ask if not provided. If no plan exists, suggest `/plan` first.
+2. Load `workflow` skill and `workflow/implement` sub-skill. Load context files per the matrix.
+3. Follow the implement workflow in full. Checkpoint after each major task.
+4. Self-review, then present results. Suggest `/review` for independent review.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/commands/plan.md
+++ b/components/opencode/config/opencode/commands/plan.md
@@ -1,0 +1,13 @@
+---
+description: Plan implementation for an approved spec — map changes, order tasks, write a plan
+---
+
+Run the plan phase of the workflow. This is an interactive process.
+
+Arguments: `/plan [spec-path-or-project-slug]`
+
+1. Identify the spec (`$1`). If a project slug is given, list specs in `projects/<slug>/specs/`. Ask if not provided. If no spec exists, suggest `/brainstorm` first.
+2. Load `workflow` skill and `workflow/plan` sub-skill. Load context files per the matrix.
+3. Follow the plan workflow in full. Present the plan at the hard gate.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/commands/review.md
+++ b/components/opencode/config/opencode/commands/review.md
@@ -1,0 +1,13 @@
+---
+description: Review code or document changes — correctness, style, completeness
+---
+
+Run the review phase of the workflow.
+
+Arguments: `/review [target]` — a file/directory path, git ref range, `staged`, or project slug. Defaults to staged changes; if nothing staged, reviews uncommitted changes.
+
+1. Identify the review target (`$1`). Ask if ambiguous.
+2. Load `workflow` skill and `workflow/review` sub-skill. Load context files per the matrix.
+3. Follow the review workflow in full. Present findings grouped by severity.
+
+$ARGUMENTS

--- a/components/opencode/config/opencode/dcp.jsonc
+++ b/components/opencode/config/opencode/dcp.jsonc
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json"
+}

--- a/components/opencode/config/opencode/instructions/shell-strategy.md
+++ b/components/opencode/config/opencode/instructions/shell-strategy.md
@@ -1,0 +1,225 @@
+---
+type: meta
+updated: 2026-04-02
+tags: []
+---
+
+# Shell Non-Interactive Strategy (Global)
+
+**Context:** OpenCode's shell environment is strictly **non-interactive**. It lacks a TTY/PTY, meaning any command that waits for user input, confirmation, or launches a UI (editor/pager) will hang indefinitely and timeout.
+
+**Goal:** Achieve parity with Claude Code's shell capabilities through internalized knowledge of non-interactive flags and environment variables.
+
+## Cognitive & Behavioral Standards
+
+To match the high-agency, autonomous capabilities of advanced models (like Claude Sonnet), this strategy enforces strict cognitive patterns. These are not just shell tips; they are **behavioral requirements** for success in this environment.
+
+**Goal:** Eliminate "human-in-the-loop" dependency during task execution.
+
+**Key Behaviors:**
+1. **Process Continuity (Turn-Taking):**
+   - **Rule:** Never stop after a tool output to "wait for instructions" unless the task is complete.
+   - **Why:** The environment is non-interactive. You must drive the workflow.
+   - **Mechanism:** Commands expecting input MUST use timeouts or explicit "yes" pipes.
+
+2. **Explicit Action Framing (Positive Constraints):**
+   - **Rule:** Follow "GOOD" (positive) instructions, ignore "BAD" (negative) assumptions.
+   - **Why:** Models follow explicit directives ("Use -y") better than prohibitions ("Don't prompt").
+   - **Mechanism:** Always preemptively supply non-interactive flags.
+
+3. **Environment Rigor (Context Awareness):**
+   - **Rule:** Assume a headless CI environment where any prompt = failure.
+   - **Why:** There is no TTY. "Asking the user" via a shell prompt causes a hang.
+   - **Mechanism:** Strictly avoid editors, pagers, and interactive modes.
+
+## 1. Core Mandates
+
+1. **Assume `CI=true`**: Act as if running in a headless CI/CD pipeline.
+2. **No Editors/Pagers**: `vim`, `nano`, `less`, `more`, `man` are BANNED.
+3. **Force & Yes**: Always preemptively supply "yes" or "force" flags.
+4. **Use Tools**: Prefer `Read`/`Write`/`Edit` tools over shell manipulation (`sed`, `echo`, `cat`).
+5. **No Interactive Modes**: Never use `-i` or `-p` flags that require user input.
+
+## 2. Environment Variables (Auto-Set)
+
+These environment variables help prevent interactive prompts:
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `CI` | `true` | General CI detection |
+| `DEBIAN_FRONTEND` | `noninteractive` | Apt/dpkg prompts |
+| `GIT_TERMINAL_PROMPT` | `0` | Git auth prompts |
+| `GIT_EDITOR` | `true` | Block git editor |
+| `GIT_PAGER` | `cat` | Disable git pager |
+| `PAGER` | `cat` | Disable system pager |
+| `GCM_INTERACTIVE` | `never` | Git credential manager |
+| `HOMEBREW_NO_AUTO_UPDATE` | `1` | Homebrew updates |
+| `npm_config_yes` | `true` | NPM prompts |
+| `PIP_NO_INPUT` | `1` | Pip prompts |
+| `YARN_ENABLE_IMMUTABLE_INSTALLS` | `false` | Yarn lockfile |
+
+## 3. Command Reference
+
+### Package Managers
+
+| Tool | Interactive (BAD) | Non-Interactive (GOOD) |
+|------|-------------------|------------------------|
+| **NPM** | `npm init` | `npm init -y` |
+| **NPM** | `npm install` | `npm install --yes` |
+| **Yarn** | `yarn install` | `yarn install --non-interactive` |
+| **PNPM** | `pnpm install` | `pnpm install --reporter=silent` |
+| **Bun** | `bun init` | `bun init -y` |
+| **APT** | `apt-get install pkg` | `apt-get install -y pkg` |
+| **APT** | `apt-get upgrade` | `apt-get upgrade -y` |
+| **PIP** | `pip install pkg` | `pip install --no-input pkg` |
+| **Homebrew** | `brew install pkg` | `HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg` |
+
+### Git Operations
+
+| Action | Interactive (BAD) | Non-Interactive (GOOD) |
+|--------|-------------------|------------------------|
+| **Commit** | `git commit` | `git commit -m "msg"` |
+| **Merge** | `git merge branch` | `git merge --no-edit branch` |
+| **Pull** | `git pull` | `git pull --no-edit` |
+| **Rebase** | `git rebase -i` | `git rebase` (non-interactive) |
+| **Add** | `git add -p` | `git add .` or `git add <file>` |
+| **Stash** | `git stash pop` (conflicts) | `git stash pop` or handle manually |
+| **Log** | `git log` (pager) | `git log --no-pager` or `git log -n 10` |
+| **Diff** | `git diff` (pager) | `git diff --no-pager` or `git --no-pager diff` |
+
+### System & Files
+
+| Tool | Interactive (BAD) | Non-Interactive (GOOD) |
+|------|-------------------|------------------------|
+| **RM** | `rm file` (prompts) | `rm -f file` |
+| **RM** | `rm -i file` | `rm -f file` |
+| **CP** | `cp -i a b` | `cp -f a b` |
+| **MV** | `mv -i a b` | `mv -f a b` |
+| **Unzip** | `unzip file.zip` | `unzip -o file.zip` |
+| **Tar** | `tar xf file.tar` | `tar xf file.tar` (usually safe) |
+| **SSH** | `ssh host` | `ssh -o BatchMode=yes -o StrictHostKeyChecking=no host` |
+| **SCP** | `scp file host:` | `scp -o BatchMode=yes file host:` |
+| **Curl** | `curl url` | `curl -fsSL url` |
+| **Wget** | `wget url` | `wget -q url` |
+
+### Docker
+
+| Action | Interactive (BAD) | Non-Interactive (GOOD) |
+|--------|-------------------|------------------------|
+| **Run** | `docker run -it image` | `docker run image` |
+| **Exec** | `docker exec -it container bash` | `docker exec container cmd` |
+| **Build** | `docker build .` | `docker build --progress=plain .` |
+| **Compose** | `docker-compose up` | `docker-compose up -d` |
+
+### Python/Node REPLs
+
+| Tool | Interactive (BAD) | Non-Interactive (GOOD) |
+|------|-------------------|------------------------|
+| **Python** | `python` | `python -c "code"` or `python script.py` |
+| **Node** | `node` | `node -e "code"` or `node script.js` |
+| **IPython** | `ipython` | Never use - always `python -c` |
+
+## 4. Banned Commands (Will Always Hang)
+
+These commands **will hang indefinitely** - never use them:
+
+- **Editors**: `vim`, `vi`, `nano`, `emacs`, `pico`, `ed`
+- **Pagers**: `less`, `more`, `most`, `pg`
+- **Manual pages**: `man`
+- **Interactive git**: `git add -p`, `git rebase -i`, `git commit` (without -m)
+- **REPLs**: `python`, `node`, `irb`, `ghci` (without script/command)
+- **Interactive shells**: `bash -i`, `zsh -i`
+
+## 5. Handling Prompts
+
+When a command doesn't have a non-interactive flag:
+
+### The "Yes" Pipe
+```bash
+yes | ./install_script.sh
+```
+
+### Heredoc Input
+```bash
+./configure.sh <<EOF
+option1
+option2
+EOF
+```
+
+### Echo Pipe
+```bash
+echo "password" | sudo -S command
+```
+
+### Timeout Wrapper (last resort)
+```bash
+timeout 30 ./potentially_hanging_script.sh || echo "Timed out"
+```
+
+## 6. Best Practices
+
+1. **Always test commands** mentally for interactive prompts before running
+2. **Check man pages** (via web search) for `-y`, `--yes`, `--non-interactive`, `-f`, `--force` flags
+3. **Use `--help`** to discover non-interactive options: `cmd --help | grep -i "non-interactive\|force\|yes"`
+4. **Prefer OpenCode tools** over shell commands for file operations
+5. **Set timeout** for any command that might unexpectedly prompt
+
+---
+
+## 7. Advanced Instruction Patterns (Cognitive Optimization)
+
+### The Problem: Implicit Constraints
+Large Language Models (LLMs) often struggle with:
+1. **Negative constraints**: Inverting or ignoring "don't do X" instructions.
+2. **Turn termination**: Stopping after tool execution instead of auto-continuing.
+3. **Context weighting**: Failing to prioritize authoritative instructions over general knowledge.
+
+### Strategy 1: Explicit Action Framing (BAD vs GOOD)
+
+This plugin uses the **BAD vs GOOD** pattern to enforce positive constraints. Instead of saying "Don't use interactive flags", we provide a concrete "Good" alternative.
+
+**Why it works:**
+- "BAD: npm init" → Model identifies the failure pattern.
+- "GOOD: npm init -y" → Model receives a specific, executable instruction.
+- **Result:** Reduces hallucination of interactive commands by providing a verified substitute.
+
+### Strategy 2: Process Continuity
+
+In non-interactive environments, the agent must drive the process forward.
+
+**The Rule:** Never stop after a tool execution unless the task is complete.
+
+**Pattern:**
+```
+1. Execute command (e.g., git status)
+2. Analyze output
+3. Explicitly state next step: "Status is clean. Next: I will run tests."
+4. Execute next step immediately
+```
+
+### Strategy 3: Context Hierarchy
+
+When instructions conflict (e.g., generic docs vs this specific strategy), establish precedence:
+
+1. **Cite the Authority:** "Per shell_strategy.md..."
+2. **Follow the Specifics:** Rules in this file override general model training or other documentation.
+
+### Strategy 4: Applying These Patterns Beyond Shell
+
+The cognitive strategies used here (Explicit Action Framing) apply to all coding tasks:
+
+**Instead of:**
+```markdown
+Do not use logging.getLogger()
+Don't create CLI code here
+```
+
+**Use:**
+```markdown
+ALWAYS USE: config.logging_config.get_logger()
+USE THIS REPO FOR: API backend only
+```
+
+By framing instructions as "Actionable Positive Constraints", you reduce hallucination and improve compliance across all models.
+

--- a/components/opencode/config/opencode/opencode.json
+++ b/components/opencode/config/opencode/opencode.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "instructions/shell-strategy.md"
+  ],
+  "plugin": [
+    "@franlol/opencode-md-table-formatter@0.0.6",
+    "@tarquinen/opencode-dcp@3.1.7"
+  ],
+  "mcp": {
+    "exa": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp",
+      "enabled": true
+    },
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "enabled": true
+    },
+    "gh_grep": {
+      "type": "remote",
+      "url": "https://mcp.grep.app",
+      "enabled": true
+    }
+  },
+  "permission": {
+    "bash": "allow",
+    "external_directory": {
+      "~/workspace/**": "allow",
+      "~/projects/**": "allow",
+      "~/src/**": "allow"
+    }
+  }
+}

--- a/components/opencode/config/opencode/skills/conventions/SKILL.md
+++ b/components/opencode/config/opencode/skills/conventions/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: conventions
+description: Commit message and MR/PR title conventions — Jira key prefix for project repos, plain description for others
+compatibility: opencode
+---
+
+# Commit & MR Title Conventions
+
+The format depends on which repo you are working in.
+
+**Project key:** Check the branch name or MR/PR title for the Jira key (e.g. `feature/PROJ-42-add-auth`). If not found there, check the MR/PR description or ask the user.
+
+## By Repo Context
+
+| Repo | Format | Example |
+|------|--------|---------|
+| **Project/code repo** | `[PROJ-123] description` | `[PROJ-42] add OAuth2 token refresh endpoint` |
+| **Other repo** | `description` | `add address-review command` |
+
+- **Project/code repos** — Jira key prefix is mandatory. No Conventional Commits type prefix.
+- **Other repos** — plain description only. No Jira key, no type prefix.
+
+## Full Format (project/code repo)
+
+```
+[PROJ-123] <short description>
+```
+
+- **`[PROJ-123]`** — Jira issue key in square brackets. Mandatory. Replace `PROJ` with the key from the branch name or MR title.
+- **`short description`** — imperative, present tense, lowercase, no trailing period. Max ~72 chars total.
+
+## Full Format (other repo)
+
+```
+<short description>
+```
+
+Plain imperative sentence describing what changed.
+
+## Examples
+
+**Project/code repo:**
+```
+[PROJ-42] add OAuth2 token refresh endpoint
+[PROJ-99] handle null response from upstream service
+[PROJ-7] upgrade eslint to v9
+[PROJ-15] add edge cases for expired token handling
+```
+
+**Other repo:**
+```
+add address-review command
+fix stale link in knowledge-graph
+update context.md with new project
+add weekly note for W14
+```
+
+## Rules
+
+- **No Jira key in non-project commits.** Commits for non-project repos describe the change, not the task.
+- **No Jira key = incomplete in project repos.** Every project commit and MR title must include `[PROJ-123]`.
+- **No Conventional Commits type prefix** (`feat:`, `fix:`, etc.) in either repo.
+- **Imperative mood.** "add", "fix", "remove" — not "added", "fixing", "removed".
+- **One concern per commit.** Don't bundle a feature and a bug fix in a single commit.
+- **MR title = the most important commit's message**, or a summary if the MR spans multiple logical changes.
+
+## Finding the Jira Key (project repos)
+
+If you don't know the Jira issue key:
+1. Check the branch name — it often contains the key (e.g., `feature/PROJ-42-add-auth`)
+2. Check the MR title or description
+3. Ask the user — do not invent or omit the key

--- a/components/opencode/config/opencode/skills/github/SKILL.md
+++ b/components/opencode/config/opencode/skills/github/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: github
+description: Work with GitHub via gh CLI — pull request lifecycle, Actions CI, issue management, repo operations
+compatibility: opencode
+---
+
+## Related Skills
+
+Load these alongside `github` when relevant:
+
+| Skill | When to load |
+|-------|-------------|
+| `conventions` | Any time you create a commit or PR title — covers the required `[PROJ-123] description` format |
+| `security` | Before pushing to any shared or production-facing branch |
+
+---
+
+`gh` is the GitHub CLI. Use it for pull requests, Actions workflows, issues, and repo operations.
+
+## Pull Requests (`gh pr`)
+
+### Create a PR
+
+```bash
+gh pr create --fill              # Auto-fill title/body from commits; push branch
+gh pr create --fill --label bugfix
+gh pr create --fill --assignee username
+gh pr create --draft             # Open as draft
+gh pr create --title "Title" --body "Description"
+```
+
+`--fill` reads branch name and commit messages to populate title and body automatically. This is the preferred way to create PRs.
+
+### View and list
+
+```bash
+gh pr view              # Current branch's PR
+gh pr view 123          # PR by number
+gh pr list              # Open PRs
+gh pr list --state all  # All states
+gh pr diff 123          # View changes
+gh pr checks 123        # View CI check status
+```
+
+### Review and merge
+
+```bash
+gh pr review 123 --approve
+gh pr review 123 --comment --body "Looks good"
+gh pr review 123 --request-changes --body "Please fix..."
+gh pr merge 123                    # Merge (auto-selects strategy)
+gh pr merge 123 --squash           # Squash merge
+gh pr merge 123 --rebase           # Rebase merge
+gh pr merge 123 --delete-branch    # Delete branch after merge
+```
+
+### Update and comment
+
+```bash
+gh pr edit 123 --title "New title"
+gh pr edit 123 --add-label bugfix --add-assignee username
+gh pr comment 123 --body "Review comment"
+gh pr ready 123          # Mark draft as ready for review
+```
+
+### Close and reopen
+
+```bash
+gh pr close 123
+gh pr reopen 123
+```
+
+---
+
+## Actions Workflows (`gh run` / `gh workflow`)
+
+### Monitor runs
+
+```bash
+gh run list                       # Recent workflow runs
+gh run list --workflow build.yml  # Filter by workflow
+gh run view 12345                 # View specific run details
+gh run view 12345 --log           # View full logs
+gh run view 12345 --log-failed    # View only failed step logs
+gh run watch 12345                # Live-watch a running workflow
+```
+
+### Jobs and retries
+
+```bash
+gh run rerun 12345                # Rerun all jobs
+gh run rerun 12345 --failed       # Rerun only failed jobs
+gh run cancel 12345               # Cancel a run
+gh workflow run build.yml         # Trigger a workflow dispatch
+gh workflow list                  # List workflows
+gh workflow view build.yml        # View workflow details
+```
+
+### Artifacts
+
+```bash
+gh run download 12345             # Download all artifacts
+gh run download 12345 -n artifact-name  # Download specific artifact
+```
+
+---
+
+## Issues (`gh issue`)
+
+### Create and view
+
+```bash
+gh issue create --title "Bug: ..." --label bug
+gh issue list                     # Open issues
+gh issue list --state all         # All states
+gh issue view 42                  # View issue
+gh issue view 42 --web            # Open in browser
+```
+
+### Update and close
+
+```bash
+gh issue edit 42 --add-label "in progress"
+gh issue close 42
+gh issue reopen 42
+gh issue comment 42 --body "Comment"
+```
+
+---
+
+## Repository Operations (`gh repo`)
+
+```bash
+gh repo list <your-github-username> --limit 10      # List user repos
+gh repo view owner/repo             # View repo info
+gh repo clone owner/repo            # Clone a repo
+gh repo fork owner/repo             # Fork a repo
+```
+
+---
+
+## API Access (`gh api`)
+
+For anything not covered by built-in commands:
+
+```bash
+gh api /user                                    # Current user
+gh api repos/owner/repo/pulls                  # List PRs via API
+gh api repos/owner/repo/actions/runs           # List workflow runs
+gh api repos/owner/repo/issues/42/comments     # Issue comments
+gh api --method POST repos/owner/repo/dispatches -f event_type=deploy  # Trigger dispatch
+```
+
+Use `gh api` with `--jq` for filtering:
+
+```bash
+gh api repos/owner/repo/pulls --jq '.[].title'
+gh api /user/repos --jq '.[] | {name, visibility}'
+```
+
+---
+
+## Common Workflows
+
+### Standard PR lifecycle
+
+```bash
+# Create PR from current branch
+gh pr create --fill
+
+# Monitor CI
+gh pr checks
+gh run watch                   # Live-watch current run
+
+# After CI passes and reviews done
+gh pr merge --squash --delete-branch
+```
+
+### Check PR before reviewing
+
+```bash
+gh pr view 123                 # Summary, status, CI
+gh pr diff 123                 # Full diff
+gh pr checkout 123             # Check out the branch locally
+```
+
+### Investigate CI failure
+
+```bash
+gh run list --branch my-branch        # Find the run
+gh run view 12345 --log-failed        # View failed logs
+gh run rerun 12345 --failed           # Retry failed jobs
+```
+
+---
+
+## Rules
+
+- **Prefer `gh pr create --fill`** -- it handles pushing and populates title/body automatically.
+- **For project/code repos, PR titles and commits must follow `[PROJ-123] description` format. For other repos, use a plain description.** No Conventional Commits type prefix. Load the `conventions` skill for the full reference. If you don't have the Jira issue key, check the branch name or ask the user.
+- **`gh pr checks`** shows CI status. **`gh run view --log-failed`** shows failure details.
+- Use `gh pr view` and `gh issue view` to pull context into daily notes -- do not copy issue descriptions verbatim, summarise and link.
+- `gh` requires authentication. Run `gh auth status` to verify.
+- The user's GitHub username and auth status can be checked with `gh auth status`.

--- a/components/opencode/config/opencode/skills/glab/SKILL.md
+++ b/components/opencode/config/opencode/skills/glab/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: glab
+description: Work with GitLab via glab CLI — merge request lifecycle, CI monitoring, issue management
+compatibility: opencode
+---
+
+`glab` is the GitLab CLI. Use it for merge requests, CI pipelines, and issues.
+
+## Related Skills
+
+Load these alongside `glab` when relevant:
+
+| Skill | When to load |
+|-------|-------------|
+| `conventions` | Any time you create a commit or MR title — covers the `[PROJ-123] description` format (no type/scope prefix) |
+| `security` | Before pushing to any shared or production-facing branch |
+| `worktrunk` | When checking out an MR branch locally |
+
+---
+
+## Merge Requests (`glab mr`)
+
+### MR Title and Commit Convention
+
+For project/code repos, MR titles and commits require a Jira issue key prefix. No Conventional Commits type prefix.
+**Load the `conventions` skill for the full format and rules.**
+
+Quick reference:
+```
+[PROJ-123] short description
+```
+
+If `--fill` produces a title that doesn't match this format, correct it:
+```bash
+glab mr update <id> --title "[PROJ-42] add short description"
+```
+
+If you don't have the Jira issue key, check the branch name or MR title.
+
+### MR Description Template
+
+When creating an MR with `--fill`, review the auto-generated description and ensure it includes:
+
+```markdown
+## Summary
+<!-- 1-3 sentences: what this MR does and why -->
+
+## Changes
+<!-- Bullet list of significant changes -->
+
+## Test Plan
+<!-- How this was tested: manual steps, automated tests, CI checks -->
+```
+
+For simple MRs, `--fill` output is often sufficient. For complex changes, edit the description to add the Summary/Changes/Test Plan structure.
+
+### Create an MR
+
+```bash
+glab mr create --fill          # Auto-fill title/description from commits; push branch
+glab mr create --fill --label bugfix  # Add label
+glab mr create --fill --assignee username
+glab mr create --draft         # Open as draft (WIP)
+```
+
+`--fill` reads branch name and commit messages to populate title and description automatically. This is the preferred way to create MRs.
+
+### View and list
+
+```bash
+glab mr view             # Current branch's MR
+glab mr view 123         # MR by number
+glab mr list             # Open MRs
+glab mr list --all       # All states
+glab mr diff 123         # View changes
+```
+
+### Approve and merge
+
+```bash
+glab mr approve          # Approve current branch's MR
+glab mr approve 123      # Approve by number
+glab mr merge 123        # Merge MR
+glab mr revoke 123       # Revoke approval
+```
+
+### Update and comment
+
+```bash
+glab mr update 123 --title "New title"
+glab mr update 123 --label bugfix --assignee username
+glab mr note 123 --message "Review comment"
+glab mr rebase 123       # Rebase source branch against target
+```
+
+### Close and reopen
+
+```bash
+glab mr close 123
+glab mr reopen 123
+```
+
+---
+
+## CI Pipelines (`glab ci`)
+
+### Monitor pipelines
+
+```bash
+glab ci view             # Live pipeline view for current branch
+glab ci view main        # Pipeline for a specific branch
+glab ci status           # Quick status of current branch's pipeline
+glab ci list             # List all pipelines
+```
+
+### Stream job logs
+
+```bash
+glab ci trace            # Stream logs of a running/failed job (interactive picker)
+glab ci trace <job-id>   # Stream specific job by ID
+glab ci trace <job-name> # Stream by job name
+```
+
+`glab ci trace` streams logs in real time — use this to monitor long-running jobs without waiting for completion.
+
+### Jobs and retries
+
+```bash
+glab ci retry <job-id>   # Retry a failed job
+glab ci trigger <job-id> # Trigger a manual job
+glab ci cancel           # Cancel current pipeline
+glab ci run              # Trigger a new pipeline
+glab ci artifact <ref> <job>  # Download job artifacts
+```
+
+---
+
+## Issues (`glab issue`)
+
+### Create and view
+
+```bash
+glab issue create --title "Bug: ..." --label bug
+glab issue list                    # Open issues
+glab issue list --all              # All states
+glab issue view 42                 # View issue
+glab issue view --web 42           # Open in browser
+```
+
+### Update and close
+
+```bash
+glab issue update 42 --label "in progress"
+glab issue close 42
+glab issue reopen 42
+glab issue note 42 --message "Comment"
+```
+
+---
+
+## Common Workflows
+
+### Standard MR lifecycle
+
+```bash
+# Create MR from current branch
+glab mr create --fill
+
+# Monitor CI
+glab ci view
+glab ci trace              # Stream failing job logs
+
+# After CI passes and reviews done
+glab mr merge 123
+```
+
+### Check MR before reviewing
+
+```bash
+glab mr view 123           # Summary, status, CI
+glab mr diff 123           # Full diff
+wt switch mr:123           # Check out the branch locally (see worktrunk skill)
+```
+
+### Fix MR review comments
+
+See the `glab/address-review` sub-skill (`~/.config/opencode/skills/glab/address-review.md`) for a structured workflow to address unresolved MR discussion threads.
+
+---
+
+## Troubleshooting
+
+### Authentication
+
+```bash
+glab auth status           # Check current auth — run this first if commands fail
+glab auth login            # Re-authenticate (interactive — run manually, not in agent)
+```
+
+If `glab` commands return 401/403 errors, check:
+1. `glab auth status` — is the token valid?
+2. Is the token scoped for the target project? (Some tokens are project-scoped.)
+3. For API-heavy operations, check rate limits.
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `could not find remote` | Branch not pushed or remote mismatch | `git push -u origin HEAD` first |
+| `404 Project Not Found` | Wrong project context or insufficient permissions | `glab repo view` to verify project |
+| `draft: true` blocking merge | MR is still in draft | `glab mr update <id> --draft=false` |
+| `pipeline failed` | CI check failed | `glab ci trace` to see logs |
+| `cannot merge: conflicts` | Branch has merge conflicts | Rebase locally, force-push, then retry |
+
+### Pipeline debugging
+
+When CI fails:
+1. `glab ci status` — identify which pipeline and stage failed
+2. `glab ci trace <job-name>` — stream the failing job's logs
+3. Look for the first error, not the last — cascading failures obscure the root cause
+4. If the job is flaky, `glab ci retry <job-id>` to re-run just that job
+
+---
+
+## Rules
+
+- **Prefer `glab mr create --fill`** — it handles pushing and populates title/description automatically.
+- **For project/code repos, prefix MR titles and commits with the Jira issue key** — e.g. `[PROJ-42] short description`. No Jira key = incomplete title. For other repos, use a plain description. Load the `conventions` skill for the full format.
+- **`glab ci view`** gives a live, interactive pipeline view. **`glab ci trace`** streams a specific job's logs.
+- Use `glab mr view` and `glab issue view` to pull context into daily notes — do not copy issue descriptions verbatim, summarise and link.
+- `glab` requires authentication. Run `glab auth status` to verify.
+- **Never force-push to `main` or `master`** without explicit user approval.
+- **Never delete remote branches** that have open MRs.

--- a/components/opencode/config/opencode/skills/glab/address-review.md
+++ b/components/opencode/config/opencode/skills/glab/address-review.md
@@ -1,0 +1,117 @@
+---
+name: glab/address-review
+description: "Address unresolved MR review comments — fetch threads, plan fixes, apply, commit, push, resolve."
+compatibility: opencode
+depends_on:
+  - glab
+---
+
+# Address MR Review Comments
+
+Structured workflow for working through unresolved discussion threads on a GitLab MR.
+
+## When to Use
+
+- User asks to "address review comments", "fix reviewer feedback", or "resolve MR threads"
+- Before marking an MR as ready after a round of review
+
+## Workflow
+
+### Step 1: Fetch Unresolved Threads
+
+Run the helper script to list all unresolved discussion threads:
+
+```bash
+python3 ~/.config/opencode/skills/glab/scripts/mr_discussions.py list <mr-id>
+```
+
+Or using `glab` directly:
+
+```bash
+glab mr view <mr-id>           # Overview including review status
+```
+
+For detailed thread content, use the MR discussions script — it fetches all threads with their notes and resolved status.
+
+If no `mr-id` is given, check the current branch:
+```bash
+glab mr view --output json | python3 -c "import sys,json; print(json.load(sys.stdin)['iid'])"
+```
+
+### Step 2: Display Threads
+
+Show the user a numbered list of unresolved threads:
+
+```
+[1] path/to/file.ts:42 — Alice: "This should handle the null case"
+[2] path/to/other.ts:17 — Bob: "Consider extracting this to a helper"
+[3] (general) — Alice: "Missing tests for the error path"
+```
+
+Include:
+- Thread number (for reference)
+- File and line (if applicable)
+- Reviewer name
+- Comment text (full, not truncated)
+
+### Step 3: Plan Fixes
+
+Before touching any code:
+1. Group related threads (e.g., multiple comments about the same function)
+2. For each thread, state the proposed fix in one sentence
+3. Flag any threads where the reviewer's intent is unclear — ask the user before guessing
+
+**`<HARD-GATE>`** — present the plan and wait for user approval before making changes.
+
+### Step 4: Apply Fixes
+
+Address threads one at a time, in the order planned. After each fix:
+- Verify the change matches what was agreed
+- Do not bundle unrelated changes — keep fixes scoped to the thread
+
+### Step 5: Commit
+
+One commit per logical group of fixes (not one per thread unless they're unrelated).
+
+Load the `conventions` skill for the required format. Quick reference:
+
+```bash
+git commit -m "[PROJ-123] address review comments from <reviewer>"
+```
+
+Use the Jira issue key from the branch name or MR title. If unclear, ask the user. Commit message should reference the review round if helpful (e.g., "address round 2 review comments").
+
+### Step 6: Push
+
+```bash
+git push
+```
+
+Monitor CI after pushing:
+```bash
+glab ci view
+```
+
+### Step 7: Resolve Threads
+
+After pushing, reply to each resolved thread and mark it resolved:
+
+```bash
+python3 ~/.config/opencode/skills/glab/scripts/mr_discussions.py reply <mr-id> <discussion-id> "Fixed in <commit-sha>"
+python3 ~/.config/opencode/skills/glab/scripts/mr_discussions.py resolve <mr-id> <discussion-id>
+```
+
+Or use `glab mr note` for a general summary comment:
+```bash
+glab mr note <mr-id> --message "Addressed all review comments from @alice — see commits <sha1>, <sha2>"
+```
+
+**Do not resolve threads without explicit user confirmation** if the fix is non-trivial or the reviewer's concern was architectural.
+
+## Rules
+
+- **Never guess reviewer intent.** If a comment is ambiguous, ask the user before fixing.
+- **One concern at a time.** Fix what was asked, not what you think should also change.
+- **Always commit before resolving.** The commit is the evidence the concern was addressed.
+- **Do not resolve threads on behalf of the reviewer** for architectural concerns — leave those for the reviewer to close.
+- **Hard gate before code changes.** Always present the plan before touching files.

--- a/components/opencode/config/opencode/skills/glab/scripts/mr_discussions.py
+++ b/components/opencode/config/opencode/skills/glab/scripts/mr_discussions.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+mr_discussions.py — GitLab MR discussion helper
+
+Fetch, reply to, and resolve MR discussion threads via the GitLab API.
+Reads GITLAB_TOKEN and GITLAB_HOST from environment (or .env file).
+
+Usage:
+    python3 mr_discussions.py list <mr-id>
+    python3 mr_discussions.py reply <mr-id> <discussion-id> "<message>"
+    python3 mr_discussions.py resolve <mr-id> <discussion-id>
+
+Environment variables (or .env in cwd/parents):
+    GITLAB_TOKEN   — personal access token with api scope
+    GITLAB_HOST    — GitLab host, e.g. gitlab.example.com (no https://)
+    GITLAB_PROJECT — project path, e.g. mygroup/myrepo
+                     (optional if run inside a git repo with a GitLab remote)
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def load_env_file() -> dict[str, str]:
+    """Walk up from cwd to find a .env file and parse it."""
+    path = Path.cwd()
+    for candidate in [path, *path.parents]:
+        env_file = candidate / ".env"
+        if env_file.exists():
+            result = {}
+            for line in env_file.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                result[key.strip()] = value.strip().strip('"').strip("'")
+            return result
+    return {}
+
+
+def get_config() -> tuple[str, str, str]:
+    """Return (token, host, project). Raises on missing required values."""
+    env = {**load_env_file(), **os.environ}
+
+    token = env.get("GITLAB_TOKEN", "")
+    host = env.get("GITLAB_HOST", "gitlab.com").rstrip("/")
+    project = env.get("GITLAB_PROJECT", "")
+
+    if not token:
+        sys.exit("Error: GITLAB_TOKEN not set. Add it to .env or export it.")
+    if not project:
+        project = _detect_project_from_git(host)
+    if not project:
+        sys.exit(
+            "Error: GITLAB_PROJECT not set and could not detect from git remote.\n"
+            "Set GITLAB_PROJECT=group/repo in .env or the environment."
+        )
+
+    return token, host, project
+
+
+def _detect_project_from_git(host: str) -> str:
+    """Try to derive project path from the git remote URL."""
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        url = result.stdout.strip()
+        # ssh: git@gitlab.example.com:group/repo.git
+        # https: https://gitlab.example.com/group/repo.git
+        if host in url:
+            path = url.split(host)[-1].lstrip(":").lstrip("/")
+            return path.removesuffix(".git")
+    except Exception:
+        pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+
+def api_request(
+    token: str,
+    host: str,
+    path: str,
+    method: str = "GET",
+    body: dict | None = None,
+) -> dict | list:
+    """Make a GitLab API request. Returns parsed JSON."""
+    url = f"https://{host}/api/v4{path}"
+    data = json.dumps(body).encode() if body else None
+    headers = {
+        "PRIVATE-TOKEN": token,
+        "Content-Type": "application/json",
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode(errors="replace")
+        sys.exit(f"API error {e.code} {e.reason} — {url}\n{body_text}")
+
+
+def encode_project(project: str) -> str:
+    return project.replace("/", "%2F")
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(token: str, host: str, project: str, mr_id: str) -> None:
+    """List unresolved discussion threads for an MR."""
+    ep = encode_project(project)
+    discussions = api_request(
+        token, host, f"/projects/{ep}/merge_requests/{mr_id}/discussions"
+    )
+
+    unresolved = []
+    for d in discussions:
+        notes = d.get("notes", [])
+        if not notes:
+            continue
+        # A thread is unresolved if any note is not resolved
+        # (system notes have no 'resolvable' field)
+        resolvable = [n for n in notes if n.get("resolvable")]
+        if resolvable and all(n.get("resolved") for n in resolvable):
+            continue  # fully resolved
+        unresolved.append((d["id"], notes))
+
+    if not unresolved:
+        print("No unresolved discussion threads.")
+        return
+
+    print(f"Unresolved threads ({len(unresolved)}):\n")
+    for i, (disc_id, notes) in enumerate(unresolved, 1):
+        first = notes[0]
+        author = first.get("author", {}).get("username", "?")
+        body = first.get("body", "").strip().replace("\n", " ")
+        pos = first.get("position", {})
+        location = ""
+        if pos:
+            new_path = pos.get("new_path") or pos.get("old_path", "")
+            new_line = pos.get("new_line") or pos.get("old_line", "")
+            if new_path:
+                location = f"{new_path}:{new_line} — "
+        print(f"[{i}] {location}@{author}: {body[:120]}")
+        print(f"     discussion_id: {disc_id}")
+        if len(notes) > 1:
+            print(f"     ({len(notes) - 1} follow-up note(s))")
+        print()
+
+
+def cmd_reply(
+    token: str, host: str, project: str, mr_id: str, disc_id: str, message: str
+) -> None:
+    """Reply to a discussion thread."""
+    if not message.strip():
+        sys.exit("Error: reply message cannot be empty.")
+    ep = encode_project(project)
+    result = api_request(
+        token,
+        host,
+        f"/projects/{ep}/merge_requests/{mr_id}/discussions/{disc_id}/notes",
+        method="POST",
+        body={"body": message},
+    )
+    print(f"Replied (note id: {result.get('id')})")
+
+
+def cmd_resolve(token: str, host: str, project: str, mr_id: str, disc_id: str) -> None:
+    """Mark a discussion thread as resolved."""
+    ep = encode_project(project)
+    api_request(
+        token,
+        host,
+        f"/projects/{ep}/merge_requests/{mr_id}/discussions/{disc_id}",
+        method="PUT",
+        body={"resolved": True},
+    )
+    print(f"Thread {disc_id} resolved.")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+USAGE = """Usage:
+    python3 mr_discussions.py list <mr-id>
+    python3 mr_discussions.py reply <mr-id> <discussion-id> "<message>"
+    python3 mr_discussions.py resolve <mr-id> <discussion-id>
+"""
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args:
+        sys.exit(USAGE)
+
+    token, host, project = get_config()
+    command = args[0]
+
+    if command == "list":
+        if len(args) < 2:
+            sys.exit("Usage: mr_discussions.py list <mr-id>")
+        cmd_list(token, host, project, args[1])
+
+    elif command == "reply":
+        if len(args) < 4:
+            sys.exit(
+                'Usage: mr_discussions.py reply <mr-id> <discussion-id> "<message>"'
+            )
+        cmd_reply(token, host, project, args[1], args[2], args[3])
+
+    elif command == "resolve":
+        if len(args) < 3:
+            sys.exit("Usage: mr_discussions.py resolve <mr-id> <discussion-id>")
+        cmd_resolve(token, host, project, args[1], args[2])
+
+    else:
+        sys.exit(f"Unknown command: {command}\n{USAGE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/components/opencode/config/opencode/skills/security/SKILL.md
+++ b/components/opencode/config/opencode/skills/security/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: security
+description: Baseline safety rules for working with production systems, credentials, and sensitive operations
+compatibility: opencode
+---
+
+# Security Rules
+
+These rules apply to all workflow phases when working with real systems, credentials, or production environments. They are non-negotiable.
+
+## Hard Rules
+
+1. **No production mutations without explicit approval.** Never write to, delete from, or modify a production system unless the user explicitly says "yes, do it in production." Describe the change; let the user execute it or confirm.
+
+2. **No secrets in code.** Never write credentials, tokens, API keys, or passwords into source files, commit messages, or log statements — even temporarily. Secrets belong in `.env` files or a secrets manager.
+
+3. **No secrets in shell commands.** Do not pass secrets as inline arguments (they appear in process lists and shell history). Use environment variables or input piping instead.
+
+4. **No `sudo` for application code.** If something requires elevated privileges, flag it for the user — do not silently add `sudo`. Privilege escalation must be deliberate.
+
+5. **No force-push to `main` or `master`.** This is a hard stop. If the user asks for it, warn them explicitly and ask for confirmation. Prefer revert commits over force-push.
+
+6. **No bypassing security controls.** Do not add `--no-verify`, disable linting, or skip pre-commit hooks without explicit approval. These exist for a reason.
+
+7. **Verify before destructive operations.** Before any `rm -rf`, `DROP TABLE`, `delete_*`, or bulk update — show what will be affected and confirm with the user.
+
+8. **No exfiltration patterns.** Never pipe file contents or env vars to external services, URLs, or clipboard commands. Data stays in the working environment.
+
+9. **Credential files are read-only.** `.env`, `credentials.json`, and similar files are for reading config. Never overwrite them without user instruction. Never log their contents.
+
+## When Working with AWS / Cloud
+
+- Default posture is **read-only**. Use `--dry-run` or equivalent before any mutating operation.
+- Always confirm the target account/region before running commands — wrong account = incident.
+- Prefer IAM roles over long-lived access keys. If keys are needed, they come from the environment — never hardcode.
+- Tag resources with the project name when creating them.
+- Every cloud command that creates, modifies, or deletes resources requires explicit user approval.
+
+## Secrets in This Repo
+
+All credentials are in `.env` at the repo root. This file is gitignored. Never commit it, log it, or include its values in any file.
+
+To read a value from `.env` in a shell command:
+```bash
+source .env && echo "loaded"   # source first, then use $VAR_NAME
+```
+
+Do not use `cat .env` to inspect it — pipe it to `grep` if you need a specific value:
+```bash
+grep "^GITLAB_TOKEN" .env
+```
+
+## Red Flags — Hard Stops
+
+If any of these appear in a request or command, **stop and verify with the user** before proceeding:
+
+| Red flag | What to do |
+|----------|------------|
+| `DROP`, `TRUNCATE`, `DELETE FROM` without `WHERE` | Show affected rows estimate first |
+| `rm -rf /` or similar root deletion | Refuse unless path is clearly safe and scoped |
+| `git push --force` to `main`/`master` | Warn and require explicit re-confirmation |
+| Any command writing to a production URL | Confirm environment and intent |
+| Exporting env vars to a file that will be committed | Stop and flag |
+| Credentials appearing in a planned commit | Stop and strip before committing |

--- a/components/opencode/config/opencode/skills/thinking/SKILL.md
+++ b/components/opencode/config/opencode/skills/thinking/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: thinking
+description: Structured reasoning for complex decisions — frame the problem, research options, compare tradeoffs, plan execution, verify the plan before acting
+compatibility: opencode
+---
+
+Use this skill when a task is genuinely complex: multiple competing options, high risk of unintended consequences, unclear requirements, or decisions that are hard to reverse.
+
+Do not use it for routine tasks (writing a daily note, creating a KB article from a template, running a standard workflow). Use it when the right path is not obvious.
+
+## The Five Phases
+
+Work through all five phases in order. Do not skip phases. Output each phase as a visible section before proceeding to the next.
+
+---
+
+### Phase 1: Frame
+
+State the problem in one or two sentences. Then answer:
+
+- What is the desired end state?
+- What are the hard constraints (things that must not break)?
+- What is the success criterion — how will we know it worked?
+- What is the reversibility? (Can this be undone easily, with effort, or not at all?)
+
+Keep this concise. If you cannot state the desired end state clearly, stop and ask the user before proceeding.
+
+---
+
+### Phase 2: Research
+
+Gather the facts needed to make a good decision. Do not reason from assumptions when you can verify.
+
+- Read the relevant files.
+- Search for all dependencies (inbound links, references, usages).
+- Check for existing patterns in the repo that constrain or inform the decision.
+- Identify what you do not know and cannot verify — call these out explicitly.
+
+Output: a bullet list of findings. Flag unknowns with `?`.
+
+---
+
+### Phase 3: Compare
+
+List the candidate approaches (minimum two, unless only one is viable). For each:
+
+- **Name:** Short label.
+- **What it does:** One sentence.
+- **Pros:** Concrete benefits.
+- **Cons / risks:** Concrete downsides.
+- **Reversibility:** Easy / With effort / Hard.
+
+Then state your recommendation and why. Be direct — "Option A because X" not "Option A might be considered because X could potentially...".
+
+---
+
+### Phase 4: Plan
+
+Write a step-by-step execution plan for the chosen approach. Each step must be:
+
+- Concrete (names a specific file, command, or action).
+- Ordered (dependencies respected).
+- Atomic (one action per step, not "update all the files").
+
+Flag any step that is irreversible with `[IRREVERSIBLE]`.
+
+---
+
+### Phase 5: Verify
+
+Before executing, run this checklist:
+
+- [ ] Every hard constraint from Phase 1 is satisfied by the plan.
+- [ ] No step breaks an existing link, reference, or dependency.
+- [ ] Irreversible steps are clearly identified and the user is aware.
+- [ ] The plan is complete — no step assumes work that is not listed.
+- [ ] The success criterion from Phase 1 can be evaluated after the plan executes.
+
+If any item fails, revise the plan in Phase 4 and re-verify. Do not proceed until all items pass.
+
+Once verified, present the plan to the user and ask for confirmation before executing any irreversible steps.
+
+---
+
+## Rules
+
+- **Never skip Phase 2.** Reasoning from assumptions causes errors. Read the files.
+- **Never skip Phase 5.** Verification catches plan gaps before they become broken repo state.
+- **One recommendation.** Do not present "it depends" as a conclusion. Make a call.
+- **Flag unknowns.** If a fact cannot be verified, say so explicitly. Do not paper over it.
+- **Ask before irreversible steps.** Even if the user said "just do it" — confirm before [IRREVERSIBLE] steps.

--- a/components/opencode/config/opencode/skills/workflow/SKILL.md
+++ b/components/opencode/config/opencode/skills/workflow/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: workflow
+description: Structured workflows for software engineering and document authoring — brainstorm, plan, implement, review, debug phases with hard approval gates
+compatibility: opencode
+---
+
+# Skill: workflow
+
+Structured workflows for software engineering and document authoring tasks. Each phase produces artifacts, and hard gates ensure user approval before moving to the next phase.
+
+## Modes
+
+The workflow operates in two modes, inferred from context:
+
+| Mode | Trigger | Artifacts |
+|------|---------|-----------|
+| **Code** | Task targets an external repository or involves writing code | Specs, plans, code changes |
+| **Document** | Task targets journal content: ADR, proposal, RFC, KB article, blog post | Specs, plans, written documents |
+
+**Detection:** If the user specifies a target repository or the task involves code changes, use code mode. If the task involves writing a document within the journal (or for external publication via `drafts/`), use document mode. When ambiguous, ask.
+
+## Sub-skills
+
+Load these on top of `workflow` for specific phases:
+
+| Phase | Sub-skill file | Trigger | Depends on |
+|-------|---------------|---------|------------|
+| Brainstorm | `workflow/brainstorm` | Exploring a problem, generating options | `workflow` |
+| Plan | `workflow/plan` | Creating an implementation plan | `workflow` |
+| Implement | `workflow/implement` | Building from an approved plan | `workflow` |
+| Review | `workflow/review` | Reviewing code changes or documents | `workflow` |
+| Debug | `workflow/debug` | Investigating a bug or error (code only) | `workflow` |
+
+## Workflow
+
+```
+brainstorm → [GATE] → plan → [GATE] → implement → review
+                                         ↑
+                        debug ────────────┘
+```
+
+Each phase can be used standalone. Not every task needs all phases — simple bug fixes skip brainstorm/plan; well-understood features can skip brainstorm.
+
+## Context Loading
+
+Before starting any workflow phase, load relevant context files from the repo root:
+
+| Phase | Files to load |
+|-------|--------------|
+| Brainstorm | `architecture.md`, `patterns.md` |
+| Plan | `architecture.md`, `patterns.md`, `testing.md` |
+| Implement | `style.md`, `patterns.md`, `testing.md`, `safety.md` |
+| Review | `style.md`, `patterns.md`, `testing.md`, `safety.md` |
+| Debug | `architecture.md`, `patterns.md` |
+
+If working in an external repo, check for equivalent context files there first. Fall back to gathering conventions from `AGENTS.md`, linter configs, and existing code.
+
+**Document mode:** Context files are optional. Load `writing` skill rules instead. If the document relates to a specific codebase (e.g., an ADR), load that codebase's context.
+
+## Artifacts
+
+| Artifact | Location | Created by |
+|----------|----------|------------|
+| Spec | `projects/<project>/specs/<slug>.md` | Brainstorm |
+| Plan | `projects/<project>/plans/<slug>.md` | Plan |
+| Code changes | Working tree (target repo) | Implement (code mode) |
+| Document | Final location or `projects/<project>/drafts/` | Implement (document mode) |
+| Review findings | Conversation (structured format) | Review |
+| Diagnosis | Conversation | Debug |
+
+## Hard Gates
+
+A `<HARD-GATE>` means: **stop and present your output to the user. Do not proceed until they approve, modify, or reject.**
+
+Gates appear at:
+1. End of brainstorm — spec must be approved before planning
+2. End of plan — plan must be approved before implementing
+3. End of debug diagnosis — fix must be approved before applying
+
+## Anti-Slop Rules
+
+These rules apply to all workflow phases:
+
+- **No ceremonial code.** No empty constructors, no unused imports, no boilerplate "just in case."
+- **No unnecessary abstractions.** Do not create interfaces with a single implementation. Do not wrap a library just to wrap it.
+- **No filler comments.** Comments explain *why*, never *what*. `// increment counter` above `counter++` is noise. Delete it.
+- **No premature generalization.** Solve the specific problem. Extract patterns only when they repeat 3+ times.
+- **No AI-slop patterns.** Do not add `try/catch` around every function. Do not add logging to every method. Do not create utility classes for one-off helpers.
+- **Match existing style.** If the codebase uses callbacks, do not introduce promises everywhere. If it uses classes, do not refactor to functions. Consistency beats personal preference.
+- **No filler prose** (document mode). No "In this document, we will explore..." — state the point directly.
+
+## Research Tool Hierarchy
+
+When investigating APIs, libraries, or unfamiliar code during any workflow phase, use tools in this priority order:
+
+| Priority | Tool | Use when |
+|----------|------|----------|
+| 1 | Codebase search (Grep/Glob) | Answer is in the working repo |
+| 2 | context7 | Need library/framework docs (query official docs) |
+| 3 | gh_grep | Need real-world usage examples from GitHub |
+| 4 | exa | Need broader web search, blog posts, Stack Overflow |
+
+**Reference, do not recall.** When a task requires knowledge of a specific API, class, or config option — look it up. Do not rely on training data for version-sensitive details.
+
+## Comment Discipline
+
+Only comment what the code cannot say: constraints, non-obvious side effects, deliberate design decisions, known limitations. Never restate what the code does. Before adding a comment, ask if a rename or restructure makes it unnecessary.
+
+## Continuation Format
+
+When ending a response mid-workflow, always close with a `▶ Next Up` block so the user knows how to continue:
+
+```
+▶ **Next Up:** `/command` — one-sentence description of what it does.
+Also available: `/other-command` — alternative next step.
+💡 `/clear` starts a fresh conversation (useful if context is stale).
+```
+
+Rules:
+- Put the recommended command in backticks and bold the label.
+- Use "Also available:" (not "Other options:") for alternatives.
+- Always mention `/clear` — users forget it exists.
+
+## Deferred Items
+
+When a workflow phase reveals out-of-scope work — bugs, improvements, refactors unrelated to the current task — do not expand scope. Instead:
+
+1. Append the item to `projects/<project>/deferred-items.md` (create if missing).
+2. One line per item: `- **YYYY-MM-DD:** <description> (discovered during <phase>)`
+3. Continue the current task without actioning the deferred item.
+
+This prevents scope creep while preserving discoveries for future planning.
+
+## Proactive Resource Enrichment
+
+**Document mode only.** After completing any workflow phase, scan for resource gaps:
+- New concepts, tools, or patterns encountered → create resource articles
+- People or teams referenced → ensure resource entries exist
+- Architectural decisions made → consider whether an ADR is needed

--- a/components/opencode/config/opencode/skills/workflow/brainstorm.md
+++ b/components/opencode/config/opencode/skills/workflow/brainstorm.md
@@ -1,0 +1,110 @@
+---
+name: workflow/brainstorm
+description: "Explore a problem space, generate approach options, produce a spec artifact."
+compatibility: opencode
+depends_on:
+  - workflow
+---
+
+# Brainstorm Phase
+
+Explore a problem before committing to a solution. Produce a spec artifact with options and a recommendation.
+
+## When to Use
+
+- Feature request or change request with unclear scope
+- Problem with multiple possible solutions
+- Architectural decision with tradeoffs
+- Document (ADR, proposal, RFC) where structure and arguments need exploration
+- Any task where jumping to implementation would be premature
+
+## Workflow
+
+### Step 0: Load Context
+
+**Code mode:**
+1. Read `architecture.md` and `patterns.md`
+2. If working in an external repo, read its `AGENTS.md` and architecture docs instead
+
+**Document mode:**
+1. Load the `writing` skill for style and formatting rules
+2. If the document relates to a codebase, load that codebase's architecture context
+3. Check `knowledge-graph.md` for related resource articles
+
+### Step 1: Understand the Problem
+
+1. Clarify the user's request. Ask questions if ambiguous.
+2. Identify the project. If unclear, ask: "Which project is this for?"
+3. **Search for existing work:** Check `knowledge-graph.md` (document mode) or codebase (code mode) for relevant material. Search for related issues: `gh issue list` / `glab issue list` (or ask the user for a link if in a project context).
+4. Check for existing specs or plans that might overlap.
+
+### Step 2: Generate Options
+
+Generate 2-3 distinct approaches. For each option:
+
+- **Name** — short descriptive label
+- **Description** — how it works (2-3 sentences)
+- **Pros** — concrete benefits
+- **Cons** — concrete drawbacks
+- **Effort** — rough estimate (small / medium / large)
+- **Risk** — what could go wrong
+
+**Document mode additions:**
+- **Audience** — who reads this and what they need from it
+- **Structure** — proposed section outline
+
+Do not generate options that are obviously bad just to fill a quota. If there is one clear approach, say so — but explain why alternatives were rejected.
+
+Apply claim provenance to pros and cons: a pro tagged **[ASSUMED]** is weaker than one tagged **[VERIFIED]**. Tag claims that depend on unverified information.
+
+### Step 3: Write the Spec
+
+Create `projects/<project>/specs/<slug>.md` using the template at `references/spec-template.md`.
+
+Fill in all sections:
+- **Problem** — what needs to change and why
+- **Constraints** — technical limits, compatibility requirements, deadlines
+- **Options** — from Step 2
+- **Recommendation** — your preferred option with rationale
+- **Open Questions** — unknowns that need answers before planning
+
+### Step 4: Hard Gate
+
+**`<HARD-GATE>`**
+
+Present a summary of the spec to the user:
+1. One-sentence problem statement
+2. Options table (name, effort, risk)
+3. Your recommendation and why
+4. Open questions (if any)
+
+Ask: "Does this spec look right? Should I adjust anything before we move to planning?"
+
+**Do not proceed to planning until the user approves.**
+
+## Claim Provenance
+
+Tag every factual claim in the spec with its evidence level:
+
+| Tag | Meaning |
+|-----|---------|
+| **[VERIFIED]** | Confirmed by reading code, running a command, or checking an authoritative source |
+| **[CITED]** | Referenced from documentation, Confluence, or Jira but not independently verified |
+| **[ASSUMED]** | Based on reasoning, pattern matching, or training data |
+
+Present **[ASSUMED]** claims as open questions when possible. This makes the spec's confidence level transparent to reviewers.
+
+## Spec Quality Checklist
+
+Before presenting the spec, verify:
+
+- [ ] Problem statement is concrete — names specific behavior, files, or systems
+- [ ] Constraints are real — not invented ("must be backward compatible" only if true)
+- [ ] Options are genuinely distinct — not minor variations of the same approach
+- [ ] Pros/cons are specific — not generic ("more maintainable")
+- [ ] Recommendation has a clear reason — not "Option A is the best"
+- [ ] Open questions are actionable — someone can answer them
+
+## Output Format
+
+The spec file is the primary artifact. The conversation summary is secondary — it helps the user decide quickly, but the file is the source of truth.

--- a/components/opencode/config/opencode/skills/workflow/debug.md
+++ b/components/opencode/config/opencode/skills/workflow/debug.md
@@ -1,0 +1,132 @@
+---
+name: workflow/debug
+description: "Investigate bugs and errors — form hypotheses, trace execution, find root cause."
+compatibility: opencode
+depends_on:
+  - workflow
+---
+
+# Debug Phase
+
+Systematically investigate bugs, errors, and unexpected behavior. Find the root cause before proposing a fix.
+
+**Note:** Debug is code-only. There is no document equivalent.
+
+## When to Use
+
+- User reports an error, exception, or unexpected behavior
+- Test failures with unclear cause
+- Performance issues or regressions
+- "It used to work and now it doesn't"
+
+## Workflow
+
+### Step 0: Load Context
+
+1. Read `architecture.md` and `patterns.md`
+2. Understand the system's structure before diving into code
+
+### Step 1: Gather Evidence
+
+Collect everything available:
+- **Debug log** — check `projects/<project>/debug-log.md` for prior entries matching the symptom or affected code area.
+- **Error message** — exact text, not paraphrased. Copy it verbatim.
+- **Stack trace** — full trace. Identify the **originating frame** (deepest frame in application code, not library code). The top of the trace is often a library; look for the first frame that's in the project's own code.
+- **Reproduction steps** — what triggers it, is it consistent or intermittent?
+- **Recent changes** — what changed since it last worked? (`git --no-pager log --oneline -20`)
+- **Environment** — local/CI/production? OS? Node/runtime version? Config differences?
+
+Ask the user for missing evidence. Do not guess.
+
+### Stack Trace Anatomy
+
+When a stack trace is provided, parse it before forming hypotheses:
+
+1. **Error type** — what class of error is this? (null ref, type error, network timeout, assertion failure)
+2. **Error message** — what does the message say literally?
+3. **Originating frame** — the deepest frame in **project code** (not `node_modules`, not standard library). This is where control entered the error path.
+4. **Call chain** — trace backwards from the originating frame to understand how execution reached that point.
+5. **Symptom vs cause** — the error message describes the symptom. The originating frame and call chain point toward the cause.
+
+### Step 2: Form Hypotheses
+
+Generate at least 2 hypotheses for the root cause. For each:
+- **Hypothesis** — one sentence describing the suspected cause
+- **Evidence for** — what supports this hypothesis
+- **Evidence against** — what contradicts it
+- **How to verify** — specific action to confirm or rule out
+
+Rank hypotheses by likelihood. Investigate the most likely first.
+
+### Step 3: Investigate
+
+For each hypothesis (most likely first):
+
+1. **Read the code** at the suspected location
+2. **Trace the execution** — follow the call chain from entry point to error
+3. **Check assumptions** — are types correct? Is data in expected shape? Are dependencies available? Are config values what they should be?
+4. **Search for patterns** — has this type of bug occurred elsewhere in the codebase? Are there related issues in git log?
+5. **Check recent changes** — `git --no-pager log --oneline -20` and `git --no-pager diff HEAD~5..HEAD -- <file>` to see what changed near the error site
+6. **Confirm or reject** the hypothesis with evidence
+
+If the first hypothesis is wrong, move to the next. If all are wrong, step back and reconsider the problem.
+
+### Step 4: Root Cause Analysis
+
+When the root cause is found, document it:
+- **What** — the specific bug (e.g., "null reference in `getUser` when session expires")
+- **Why** — how it came to be (e.g., "session middleware doesn't set user on expired tokens, but `getUser` assumes it's always present")
+- **Where** — exact file and line
+- **When** — conditions that trigger it
+
+### Step 5: Propose Fix
+
+Design the fix:
+- **Change** — what to modify
+- **Why this fix** — why this approach over alternatives
+- **Side effects** — what else might be affected
+- **Test** — how to verify the fix works and doesn't break other things
+
+### Step 6: Hard Gate
+
+**`<HARD-GATE>`**
+
+Present the diagnosis:
+1. Root cause (1-2 sentences)
+2. Evidence that confirms it
+3. Proposed fix
+4. Risk assessment
+
+Ask: "Does this diagnosis make sense? Should I apply the fix?"
+
+**Do not apply the fix until the user approves.** The investigation itself is valuable — the user may want to handle the fix differently.
+
+## Red Flags — Hard Stops
+
+If any of these are true, **stop and reassess** before continuing:
+
+| Red flag | What it means |
+|----------|---------------|
+| Fix is larger than 10 lines | Root cause is probably wrong. Step back to Phase 2. |
+| Fix requires changes in 3+ files | The bug is architectural, not local. Declare an architectural review. |
+| Fix breaks another test | The original design contract was violated. Re-examine assumptions. |
+| Same bug recurs after fixing | The fix addressed a symptom, not the cause. Restart from Phase 1. |
+| 3+ failed fix attempts on the same bug | Architectural problem. Stop adding fixes. Restart from Phase 1 with fresh eyes. |
+
+Three or more failed fix attempts indicate an **architectural problem**. Stop patching. Declare an architectural review and present findings to the user before trying again.
+
+## Debug Principles
+
+- **Evidence over intuition.** Read the code. Do not assume you know what it does.
+- **Reproduce first.** If you cannot reproduce it, you cannot verify the fix.
+- **One change at a time.** Do not fix multiple things simultaneously — you will not know which fix worked.
+- **Check the obvious.** Typos, wrong variable names, off-by-one errors, missing imports. Check these before building complex theories.
+- **Bisect when stuck.** If recent changes are suspect, use `git log` to narrow down when the bug was introduced.
+- **Do not patch symptoms.** If the error is a null reference, do not just add a null check. Find out why it is null.
+- **Validate the fix.** Run the full test suite. An unvalidated fix is a guess, not a solution.
+
+## Debug Knowledge Base
+
+After resolving a bug, append an entry to `projects/<project>/debug-log.md` (create if missing). Use the template at `~/.config/opencode/templates/debug-log.md`. One entry per bug, flat append-only format.
+
+Before investigating a new bug, scan `debug-log.md` for prior entries matching the symptom, affected code area, or error pattern. This builds institutional memory across sessions and prevents re-investigating known issues.

--- a/components/opencode/config/opencode/skills/workflow/implement.md
+++ b/components/opencode/config/opencode/skills/workflow/implement.md
@@ -1,0 +1,145 @@
+---
+name: workflow/implement
+description: "Execute an approved plan — write code, documents, or both."
+compatibility: opencode
+depends_on:
+  - workflow
+---
+
+# Implement Phase
+
+Execute an approved plan by writing code or documents, validating output, and tracking progress.
+
+## When to Use
+
+- After a plan is approved (normal flow)
+- For small, clear tasks that skip brainstorm/plan phases
+- When the user says "implement", "build", "code", "write", or "do it"
+
+## Workflow
+
+### Step 0: Load Context
+
+**Code mode:**
+1. Read `style.md`, `patterns.md`, `testing.md`, `safety.md`
+2. Read the approved plan (`projects/<project>/plans/<slug>.md`)
+3. If no plan exists, confirm the task is small enough to proceed without one
+4. If the code touches security-sensitive areas (auth, credentials, prod systems), load the `security` skill
+
+**Document mode:**
+1. Load the `writing` skill
+2. Read the approved plan
+3. Gather source material identified in the plan
+
+### Step 1: Execute Tasks
+
+For each task in the plan:
+
+1. **Read** the target files. Understand existing code or content before changing it.
+2. **Write** the changes. Follow the project's existing style exactly.
+3. **Validate** after each significant change:
+   - Code mode: run tests if a test suite exists
+   - Document mode: verify cross-links, front matter, style compliance
+4. **Check off** the task in the plan file (`- [x]`).
+5. **Commit** at natural boundaries if the user has asked for commits. Load the `conventions` skill for the required commit message format.
+
+### Step 2: Self-Review
+
+Before presenting results:
+
+**Code mode:**
+- [ ] All plan tasks completed (or explicitly deferred with reason)
+- [ ] No debug artifacts left (console.log, print statements, TODO hacks)
+- [ ] New code follows existing patterns — not introducing a new style
+- [ ] Error handling is present at boundaries
+- [ ] No unused imports, variables, or dead code added
+- [ ] Tests pass (if test suite exists)
+
+**Document mode:**
+- [ ] All plan tasks completed (or explicitly deferred with reason)
+- [ ] Front matter is complete — title, tags, updated date
+- [ ] Style matches `writing` skill rules — no filler, active voice, tables over prose
+- [ ] Cross-links are valid — all referenced files exist
+- [ ] Knowledge-graph updated if this is a resource article
+- [ ] Tags registered in `tags.md` if new tags introduced
+
+### Step 3: Present Results
+
+Summarize what was done:
+1. List of files changed (with brief description of each change)
+2. Tests added or modified (code mode) / cross-links updated (document mode)
+3. Any deviations from the plan (and why)
+4. Remaining work (if any)
+
+### Step 4: Resource Enrichment Scan
+
+**Document mode only.** After implementation, scan for resource gaps:
+- New concepts encountered → create resource stubs
+- People or teams referenced → verify resource entries exist
+- Tools or processes used → check for resource articles
+
+## Implementation Rules
+
+### Analysis Paralysis Guard
+
+If you have read 5+ files without writing any changes, stop. State what you have learned, what is blocking action, and propose a next step. Do not continue reading. For genuinely complex tasks that require broad context (e.g., large refactors across many files), the threshold may be higher — but you must justify it explicitly before continuing to read.
+
+### Deferred Items
+
+When implementation reveals out-of-scope work — bugs, improvements, refactors unrelated to the current task — do not expand scope. Append the item to `projects/<project>/deferred-items.md` (create if missing) with format: `- **YYYY-MM-DD:** <description> (discovered during implementation)`. Continue the current task.
+
+### Match the Codebase / Journal Style
+
+- Use the same formatting, naming conventions, and patterns as existing content.
+- If the codebase uses `snake_case`, do not introduce `camelCase`.
+- If the journal uses specific section headings, follow them exactly.
+- When in doubt, find 3 similar examples and follow their pattern.
+
+### Write Minimal Code / Content
+
+- Solve the specific problem. Do not add features or sections "while you're in there."
+- Do not refactor adjacent code unless it is part of the plan.
+- Do not add abstractions that are not needed yet.
+- Prefer clear, obvious output over clever, compact output.
+
+### Test Discipline (Code Mode)
+
+- Every new function gets at least one test (if a test framework exists).
+- Every bug fix gets a regression test.
+- Test the behavior, not the implementation.
+- Do not mock the unit under test.
+
+### Error Handling (Code Mode)
+
+- Handle errors at the appropriate level — not everywhere.
+- Provide context in error messages: what operation failed, with what input.
+- Never swallow errors silently (empty catch blocks).
+- Distinguish between expected errors (bad input) and unexpected errors (bugs).
+
+### Validation is Mandatory
+
+An unvalidated output is a draft, not a deliverable. Before presenting results:
+
+**Code mode:**
+1. Run the project's test suite (if one exists)
+2. Run linters/formatters (if configured)
+3. Both must pass. If either fails, fix the issue before presenting.
+
+**Document mode:**
+1. Verify all cross-links resolve to existing files
+2. Verify front matter is complete and valid
+3. Verify style compliance with `writing` skill rules
+
+If no validation mechanism exists, state that explicitly — do not silently skip validation.
+
+### Checkpointing
+
+For large implementations (5+ tasks), checkpoint at natural boundaries. Three checkpoint types:
+
+| Type | When | Frequency |
+|------|------|-----------|
+| **human-verify** | Confirm correctness of output before continuing | ~90% of checkpoints |
+| **human-decision** | Choose between alternatives the agent cannot resolve | ~9% |
+| **human-action** | User must do something the agent cannot (e.g., run a local GUI, approve a deployment) | ~1% |
+
+Default: automate everything; checkpoint only what requires human judgment. If something unexpected comes up mid-implementation, pause and inform the user. If the plan needs adjustment, say so rather than silently deviating.

--- a/components/opencode/config/opencode/skills/workflow/plan.md
+++ b/components/opencode/config/opencode/skills/workflow/plan.md
@@ -1,0 +1,143 @@
+---
+name: workflow/plan
+description: "Create an implementation plan from an approved spec or clear task description."
+compatibility: opencode
+depends_on:
+  - workflow
+---
+
+# Plan Phase
+
+Turn an approved spec (or a well-understood task) into an ordered implementation plan with file-level detail.
+
+## When to Use
+
+- After a spec is approved (normal flow)
+- For medium-to-large tasks that touch multiple files
+- When the user asks to "plan" or "break down" a task
+- Skip for trivial changes (single-file fixes, typo corrections)
+
+## Workflow
+
+### Step 0: Load Context
+
+**Code mode:**
+1. Read `architecture.md`, `patterns.md`, `testing.md`
+2. Read the approved spec if one exists (`projects/<project>/specs/<slug>.md`)
+3. Check for `specs/CONTEXT-<slug>.md` alongside the spec. If it exists, read it — it contains resolved gray areas and pre-researched context that you or the user created manually before planning. If it does not exist, proceed — it is optional.
+
+**Document mode:**
+1. Load the `writing` skill for style and formatting rules
+2. Read the approved spec if one exists
+3. Check for `specs/CONTEXT-<slug>.md` alongside the spec (same as code mode above). If it does not exist, proceed — it is optional. This file is created manually to capture pre-researched context before planning.
+4. Identify source material — check existing resource articles, external references, and any Confluence pages or Jira issues the user provides.
+5. Identify cross-links needed (knowledge-graph, related resources, project dashboards)
+
+### Step 1: Map the Change
+
+**Code mode:**
+1. Identify all files that need to change. Read each one.
+2. Map dependencies — what calls what, what imports what.
+3. Identify integration points — where new code meets existing code.
+4. Check for tests that cover affected code.
+
+**Document mode:**
+1. Identify the document's final location (e.g., `resources/adr/`, `drafts/`, `resources/<domain>/`).
+2. Identify existing content to reference or update.
+3. List sources to consult (Confluence, Jira, existing resource articles, external docs).
+4. Identify cross-links needed (knowledge-graph, related resources, project dashboards).
+
+### Step 2: Order the Tasks
+
+Before listing tasks, define the end state (goal-backward planning):
+- `TRUE:` <behaviors that must hold>
+- `EXIST:` <artifacts that must exist>
+- `WIRED:` <integrations that must be connected>
+
+Then create an ordered task list. Each task:
+
+- **Has a clear deliverable** — "Create `UserService.ts` with `getPermissions` method" or "Write Background section covering X, Y, Z"
+- **Specifies affected files** — exact paths
+- **Describes the change** — what to add, modify, or remove
+- **Is independently verifiable** — can confirm correctness before moving on
+
+**Code mode ordering:**
+1. Data model / type changes first (foundation)
+2. Business logic second
+3. Integration / wiring third
+4. Tests alongside or immediately after each piece
+5. Cleanup and documentation last
+
+**Document mode ordering:**
+1. Research and source gathering first
+2. Core content sections (in logical reading order)
+3. Cross-references and links
+4. Front matter, tags, knowledge-graph updates last
+
+### Step 3: Define Test/Verification Strategy
+
+**Code mode:** For each significant change — what tests to add, what to assert, edge cases, integration verification.
+
+**Document mode:** Verification checklist — style compliance, completeness vs spec, cross-links valid, front matter correct, knowledge-graph updated.
+
+### Step 4: Assess Risks
+
+Identify what could go wrong:
+- Breaking changes to existing behavior (code) or contradicting existing resources (document)
+- Performance implications (code) or audience mismatch (document)
+- Migration requirements / rollback strategy
+
+### Step 5: Write the Plan
+
+Create `projects/<project>/plans/<slug>.md` using the template at `references/plan-template.md`.
+
+### Step 6: Hard Gate
+
+**`<HARD-GATE>`**
+
+Present a summary:
+1. Number of tasks and estimated scope
+2. Task list (abbreviated — task names only)
+3. Key risks
+4. Test/verification strategy summary
+
+Ask: "Does this plan look right? Should I adjust the scope, ordering, or approach?"
+
+**Do not proceed to implementation until the user approves.**
+
+## Plan Quality Checklist
+
+Before presenting the plan, verify:
+
+- [ ] Tasks are ordered by dependency — no task depends on a later task
+- [ ] No circular dependencies; parallelizable tasks not serialized
+- [ ] Each task names specific files — no vague "update the service layer"
+- [ ] Test/verification strategy exists for non-trivial changes
+- [ ] Risks are honest — not "no risks identified" for complex changes
+- [ ] No task is too large — if a task would take >30 minutes of agent work, split it
+- [ ] Plan accounts for existing content — does not reinvent what already exists
+- [ ] Plan does not contradict style, patterns, or safety context files
+- [ ] Deliverables match the spec (if one exists) — no more, no less
+
+**Guard: run this checklist silently before presenting.** If any item fails, revise the plan. If a gap cannot be resolved (missing information, ambiguous requirement), present the plan with explicit open questions rather than guessing.
+
+## Inline Plans
+
+For tasks that do not warrant a spec (user gives a clear, scoped task), create the plan directly. Skip the spec phase. The plan file still goes in `projects/<project>/plans/`.
+
+If the task is too small for even a plan file (single file, <20 lines changed), skip the plan phase entirely and go straight to implementation.
+
+## Planning Rules
+
+### Scope Reduction Prohibition
+
+Never silently reduce scope. If a spec calls for X, the plan must deliver X. If X is genuinely infeasible, state the conflict explicitly and ask the user — do not substitute a simpler version.
+
+### Goal-Backward Planning
+
+Start from the end state. Define:
+- **TRUE:** what behaviors must hold when done
+- **EXIST:** what artifacts must exist
+- **WIRED:** what integrations must be connected
+
+Then work backward to derive the task list. This produces better dependency ordering than forward listing.

--- a/components/opencode/config/opencode/skills/workflow/references/plan-template.md
+++ b/components/opencode/config/opencode/skills/workflow/references/plan-template.md
@@ -1,0 +1,32 @@
+---
+title: "<Feature Name> — Implementation Plan"
+status: draft
+spec: "specs/<slug>.md"
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+tags: [p-<project>]
+---
+
+# <Feature Name> — Implementation Plan
+
+## Tasks
+
+- [ ] 1. <Task description>
+  - **Files:** `path/to/file.ts`
+  - **Changes:** <what to add, modify, or remove>
+
+- [ ] 2. <Task description>
+  - **Files:** `path/to/file.ts`
+  - **Changes:** <what to add, modify, or remove>
+
+- [ ] 3. <Task description>
+  - **Files:** `path/to/file.test.ts`
+  - **Changes:** <what tests to add>
+
+## Test Strategy
+
+<What to test, how to test it, edge cases to cover.>
+
+## Risks
+
+- <What could go wrong and how to mitigate>

--- a/components/opencode/config/opencode/skills/workflow/references/spec-template.md
+++ b/components/opencode/config/opencode/skills/workflow/references/spec-template.md
@@ -1,0 +1,53 @@
+---
+title: "<Feature Name>"
+status: draft
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+tags: [p-<project>]
+---
+
+# <Feature Name>
+
+## Problem
+
+<What needs to change and why. Be specific — name the behavior, system, or user need.>
+
+## Constraints
+
+<Technical limits, compatibility requirements, deadlines. Only real constraints — do not invent them.>
+
+## Options
+
+### Option A: <Name>
+
+<How it works — 2-3 sentences.>
+
+**Pros:**
+- <concrete benefit>
+
+**Cons:**
+- <concrete drawback>
+
+**Effort:** <small / medium / large>
+**Risk:** <what could go wrong>
+
+### Option B: <Name>
+
+<How it works — 2-3 sentences.>
+
+**Pros:**
+- <concrete benefit>
+
+**Cons:**
+- <concrete drawback>
+
+**Effort:** <small / medium / large>
+**Risk:** <what could go wrong>
+
+## Recommendation
+
+<Which option and why. Reference specific tradeoffs.>
+
+## Open Questions
+
+- <Question that needs answering before planning>

--- a/components/opencode/config/opencode/skills/workflow/review.md
+++ b/components/opencode/config/opencode/skills/workflow/review.md
@@ -1,0 +1,124 @@
+---
+name: workflow/review
+description: "Review code changes or documents against project conventions, find issues, suggest fixes."
+compatibility: opencode
+depends_on:
+  - workflow
+---
+
+# Review Phase
+
+Systematically review code changes or documents for correctness, style, completeness, and quality.
+
+## When to Use
+
+- User asks to review code, a diff, a PR/MR, or a document
+- After implementation, before merging or publishing
+- When examining unfamiliar code or content to assess quality
+
+## Workflow
+
+### Step 0: Load Context
+
+**Code mode:**
+1. Read `style.md`, `patterns.md`, `testing.md`, `safety.md`
+2. If reviewing a PR/MR, fetch the diff and description:
+   - **GitLab MR:** load the `glab` skill, use `glab mr diff <id>`
+   - **GitHub PR:** load the `github` skill, use `gh pr diff <id>`
+3. To review commit messages against convention, load the `conventions` skill
+
+**Document mode:**
+1. Load the `writing` skill for style and formatting rules
+2. Read the document and any related spec or plan
+
+### Step 1: Gather the Material
+
+**Code mode — determine what to review:**
+- **Git diff:** `git --no-pager diff` or `git --no-pager diff branch...HEAD`
+- **Specific files:** Read the files the user specified
+- **MR/PR:** Use `glab` or `gh` to fetch the diff
+- **Recent changes:** `git --no-pager log --oneline -10` + diffs of relevant commits
+
+**Document mode — determine what to review:**
+- Read the document in full
+- Read the spec/plan it was based on (if any)
+- Check cross-links and referenced resources
+
+### Step 2: Analyze
+
+#### Code Mode Categories
+
+Review in this order — stop early if critical issues are found.
+
+**Correctness:** Does the code do what it claims? Edge cases handled? Error paths covered? Does it break existing behavior or contracts?
+
+**Security:**
+- No secrets, tokens, or credentials in code or comments
+- Input validated and sanitised at all trust boundaries
+- Parameterized queries — no string concatenation for SQL/commands
+- Auth checks present where required
+- No insecure deserialization, path traversal, or prototype pollution patterns
+
+**Performance:**
+- No unnecessary allocations in hot paths
+- No N+1 queries — check loops that call DB/API
+- No blocking calls in async contexts
+- No unbounded loops or quadratic algorithms on untrusted input
+
+**Style:** Matches project conventions? Consistent naming? Appropriate abstraction level? No dead code left in?
+
+**Testing:** New code has tests? Tests cover important paths and edge cases? Tests describe behavior, not implementation details?
+
+#### Document Mode Categories
+
+**Completeness:** Does it cover everything the spec/plan outlined? Are there gaps?
+
+**Accuracy:** Are facts correct? Do cross-references point to the right targets? Are dates and names accurate?
+
+**Clarity:** Is the writing clear and concise? Does it follow `writing` skill rules? No filler or jargon without explanation?
+
+**Structure:** Does it follow the expected template? Are sections in the right order? Is front matter complete?
+
+**Audience fit:** Will the intended reader understand this? Is the level of detail appropriate?
+
+### Step 3: Write Findings
+
+Present findings in structured format:
+
+```
+### <severity>: <short title>
+
+**Location:** `path/to/file.ts:42`
+**Issue:** <what's wrong and why it matters>
+**Recommendation:** <specific fix or alternative>
+```
+
+For document reviews, use section references instead of file:line:
+```
+**Location:** Section: Background, paragraph 2
+```
+
+Severity levels:
+
+| Severity | Meaning | Action |
+|----------|---------|--------|
+| `critical` | Bug, security issue, factual error, data loss risk | Must fix before merge/publish |
+| `warning` | Wrong pattern, missing content, misleading text, missing tests | Should fix |
+| `nit` | Style, naming, minor improvement | Nice to have |
+
+### Step 4: Summary
+
+After all findings:
+1. Total finding count by severity: e.g. "2 critical, 1 warning, 3 nits"
+2. Overall assessment: **"Approve"**, **"Approve with nits"**, or **"Request changes"**
+3. Offer: "Want me to fix the critical/warning issues?"
+
+If there are no critical or warning findings: approve. If there are critical findings: request changes regardless of anything else.
+
+## Review Principles
+
+- **Be specific.** "This function doesn't handle the case where `userId` is undefined" beats "needs better error handling."
+- **Be constructive.** Every criticism includes a recommendation.
+- **Be proportional.** Do not block a merge over nits. Do not approve with unhandled security issues or factual errors.
+- **Respect intent.** Understand what the author was trying to do before suggesting a different approach.
+- **No style wars.** If the codebase/document set is inconsistent, point it out once. Do not rewrite everything.

--- a/components/opencode/config/opencode/skills/worktrunk/SKILL.md
+++ b/components/opencode/config/opencode/skills/worktrunk/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: worktrunk
+description: Manage git worktrees with wt — create, switch, list, merge, and remove worktrees; check out MR branches
+compatibility: opencode
+---
+
+`wt` (worktrunk) is installed and available. Use it for all worktree operations.
+
+## Commands
+
+### `wt switch` — Switch to a worktree; create if needed
+
+```bash
+wt switch <branch>            # Switch to existing worktree (creates one if absent)
+wt switch --create <branch>   # Create new branch and worktree
+wt switch --create <branch> --base <base>  # New branch from specific base
+wt switch -                   # Previous worktree (like cd -)
+wt switch ^                   # Default branch worktree
+wt switch mr:<N>              # Check out GitLab MR !N's branch
+wt switch pr:<N>              # Check out GitHub PR #N's branch
+```
+
+`mr:<N>` and `pr:<N>` require `glab` (GitLab) or `gh` (GitHub) CLI to be authenticated.
+
+**Useful flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--create` / `-c` | Create a new branch |
+| `--base <branch>` / `-b` | Base branch for `--create` (default: default branch) |
+| `--execute <cmd>` / `-x` | Run a command after switching (replaces `wt` process) |
+| `--branches` | Include branches without worktrees in picker |
+| `--clobber` | Remove stale path at target |
+| `-y` | Skip approval prompts |
+
+**Interactive picker:** `wt switch` with no arguments opens a picker. Preview tabs (toggle with `1`–`5`): HEAD diff, log, diff vs main, remote diff, LLM summary. `Alt-c` creates a new worktree from the query.
+
+### `wt list` — List worktrees and their status
+
+```bash
+wt list             # Table of all worktrees
+wt list --full      # Include CI status, line diffs, LLM summaries
+wt list --branches  # Include branches without worktrees
+wt list --format=json  # JSON output for scripting
+```
+
+**Status symbols:**
+
+| Symbol | Meaning |
+|--------|---------|
+| `+` | Staged files |
+| `!` | Modified files (unstaged) |
+| `?` | Untracked files |
+| `⊂` | Content integrated into default branch (safe to remove) |
+| `_` | Same commit as default branch (safe to remove) |
+| `↑` | Ahead of default branch |
+| `↓` | Behind default branch |
+
+Rows dimmed when safe to delete (`_` or `⊂`).
+
+### `wt merge` — Merge current branch into target
+
+```bash
+wt merge            # Merge into default branch (squash + rebase + FF + cleanup)
+wt merge develop    # Merge into a different branch
+wt merge --no-squash   # Keep individual commits
+wt merge --no-ff       # Create merge commit (semi-linear history)
+wt merge --no-remove   # Keep worktree after merge
+```
+
+**Pipeline:** squash → rebase → pre-merge hooks → fast-forward merge → pre-remove hooks → cleanup → post-merge hooks.
+
+Cleanup removes the worktree and branch. Branch deletion only happens when merging would add nothing (checks: same commit, ancestor, no added changes, trees match, merge adds nothing).
+
+### `wt remove` — Remove worktree; delete branch if merged
+
+```bash
+wt remove                    # Remove current worktree
+wt remove <branch>           # Remove specific worktree
+wt remove --no-delete-branch # Keep branch after removal
+wt remove -D                 # Force-delete unmerged branch
+wt remove -f                 # Force removal (ignore untracked files)
+```
+
+Removal runs in the background by default. Logs at `.git/wt/logs/<branch>-remove.log`.
+
+---
+
+## Common Workflows
+
+### Work on a feature branch
+
+```bash
+wt switch --create feature-xyz   # Create worktree + branch
+# … do work …
+wt merge                         # Squash, rebase, merge, cleanup
+```
+
+### Review a GitLab MR
+
+```bash
+wt switch mr:101                 # Check out MR !101's branch
+# … review, test …
+wt remove                        # Clean up when done
+```
+
+### See what's in flight
+
+```bash
+wt list --full                   # All worktrees with CI status
+```
+
+---
+
+## Rules
+
+- **Use `wt` for worktree operations**, not raw `git worktree` commands.
+- **`wt switch --create`** creates both the branch and worktree in one step.
+- **`wt merge`** merges current → target (opposite direction from `git merge`).
+- **`mr:<N>` / `pr:<N>` shortcuts** require the respective CLI (`glab` or `gh`) to be authenticated.
+- **`-x` / `--execute`** runs a command after switching — useful for launching editors or other tools. It replaces the `wt` process with the command, giving it full terminal control.

--- a/components/opencode/config/opencode/skills/writing/SKILL.md
+++ b/components/opencode/config/opencode/skills/writing/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: writing
+description: Write or edit any content — KB articles, ADRs, READMEs, proposals, structured notes — following style and structure rules
+compatibility: opencode
+---
+
+## Language & Style
+
+- **Active voice.** Specify who or what acts. Prefer verbs over nouns: "compacts the history" not "performs history compaction". Use passive only when the actor is irrelevant.
+- **No nominalizations.** "Configure the server" not "make a configuration of the server." "Analyze the response" not "perform an analysis of the response."
+- **Imperative mood for instructions.** "Click **Submit**" not "The user should click Submit."
+- **Cut filler.** Delete words that add no meaning: "basically", "essentially", "in order to", "it should be noted that", "comprehensive", "robust", "leverages". If a sentence works without a word, drop it.
+- **No marketing language.** Do not write "powerful", "seamless", "cutting-edge", "world-class", "innovative", "state-of-the-art". Describe what the thing _does_, not how impressive it is.
+- **No ceremonial phrasing.** State the fact. Never write "It is important to note that" or "This section provides an overview of."
+- **Be concrete.** "Retries with exponential backoff" is better than "sophisticated retry mechanism". "200+ C# projects" is better than "a large number of projects".
+- **Short sentences.** One idea per sentence. Target 15–20 words. If a sentence has more than two commas, split it.
+- **Front-load.** Put the most important information first.
+- **Say it once.** Link instead of repeating.
+
+## Structure
+
+- **Tables and bullets over prose.** Use prose only when a list would fragment meaning.
+- **Numbered lists for sequential steps only.** Bullets for everything else.
+- **Headings as labels.** Short noun phrases, not sentences.
+- **Lead with outcome.** State the result or decision first, then context, then details.
+
+## Formatting
+
+- **UI elements:** Bold buttons, menus, labels. Example: Click **Save**, go to **Settings > Profile**.
+- **Code and paths:** `inline code` for filenames, paths, variables, endpoints, method names, config keys, short commands.
+- **Code blocks:** Triple backticks with a language identifier. Add brief inline comments for non-obvious logic.
+- **Bold** key terms and decision outcomes on first use in a section.
+
+---
+
+## Editor checklist (run silently before every output)
+
+**Style:**
+- [ ] Any filler, marketing words, or useless adjectives? Delete them.
+- [ ] Any nominalizations? Replace with verbs.
+- [ ] Any passive voice where the actor is known? Make it active.
+- [ ] All instructions in imperative mood?
+- [ ] Sentences under 20 words?
+
+**Structure:**
+- [ ] Steps numbered; non-sequential items bulleted?
+- [ ] Tables used for comparisons and structured data?
+- [ ] Headings are short noun phrases, not sentences?
+
+---

--- a/components/opencode/config/opencode/templates/debug-log.md
+++ b/components/opencode/config/opencode/templates/debug-log.md
@@ -1,0 +1,19 @@
+---
+type: log
+updated: YYYY-MM-DD
+tags: [p-<project>]
+---
+
+# Debug Log
+
+Append-only log of resolved bugs. Newest entries first. Check before investigating new bugs — the pattern may already be known.
+
+<!-- Entry format — copy and fill for each new entry:
+
+### YYYY-MM-DD: <one-line symptom>
+- **Root cause:** <what was wrong>
+- **Fix:** <what was changed>
+- **Files:** `path/to/affected/file`
+- **Pattern:** <category — e.g., null reference, race condition, config mismatch>
+
+-->

--- a/components/opencode/config/opencode/templates/draft-template.md
+++ b/components/opencode/config/opencode/templates/draft-template.md
@@ -1,0 +1,29 @@
+---
+type: draft
+target: "{{TARGET}}"
+status: draft
+updated: {{DATE}}
+tags: []
+---
+
+# {{TITLE}}
+
+**Target:** {{TARGET}}
+**Status:** draft
+**Tags:**
+
+## Audience
+
+Who is this for? What context do they have?
+
+## Key Points
+
+-
+
+## Content
+
+{{CONTENT}}
+
+## Review Notes
+
+- **{{DATE}}:** Draft started.

--- a/components/opencode/symlinks/opencode.yaml
+++ b/components/opencode/symlinks/opencode.yaml
@@ -1,0 +1,31 @@
+# MIT License
+#
+# Copyright (c) 2025 Andrew Vasilyev <me@retran.me>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# @file: components/opencode/symlinks/opencode.yaml
+# @brief: Symlink configuration for OpenCode global config.
+#         ~/.config/opencode is symlinked whole-dir. OpenCode writes
+#         node_modules/, bun.lock, package.json into .installed/ (gitignored).
+# @author: Andrew Vasilyev
+# @license: MIT
+#
+- source: "$MEOW/.installed/components/opencode/config/opencode"
+  target: "$HOME/.config/opencode"


### PR DESCRIPTION
## Summary

Adds a new `opencode` component providing a full OpenCode AI agent configuration — skills, slash commands, MCP servers, and a shell strategy guide — managed as a dotfiles component.

## Changes

- **`components/opencode/`** — new component with `component.yaml` (depends on `ai-tools`, `development-essential`), symlink config, and full `~/.config/opencode/` tree
- **Skills:** `workflow` (brainstorm/plan/implement/review/debug sub-skills), `writing`, `thinking`, `conventions`, `security`, `github`, `glab` (+ `address-review` sub-skill + `mr_discussions.py` script), `worktrunk`
- **Commands:** `/brainstorm`, `/plan`, `/implement`, `/review`, `/debug`, `/draft`
- **MCP servers:** `exa`, `context7`, `gh_grep` (remote)
- **Templates:** `debug-log.md`, `draft-template.md`
- **`components/development-essential/packages/homebrew.list`** — add `glab` and `worktrunk`

## Test Plan

Manually verified against live OpenCode session. Skills loaded and commands exercised during authoring.